### PR TITLE
fix(core): Fix newDefaultScheduler argument order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ export const newClockTimer = () => new ClockTimer()
 
 export const newScheduler = curry2(_newScheduler)
 
-export const newDefaultScheduler = () => _newScheduler(newTimeline(), newClockTimer())
+export const newDefaultScheduler = () => _newScheduler(newClockTimer(), newTimeline())
 
 export { Scheduler, Timeline, ClockTimer }
 


### PR DESCRIPTION
AFFECTS: @most/core

🤦‍♂️ Enforcing index's own types upon itself would have prevented this.  I'll see if that is easy to do.