### PR TITLE
feat(core): Add task arg to PropagateTask run function

### DIFF
--- a/src/combinator/delay.js
+++ b/src/combinator/delay.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import { propagateEvent, propagateEnd } from '../scheduler/PropagateTask'
+import { propagateEventTask, propagateEndTask } from '../scheduler/PropagateTask'
 
 /**
  * @param {Number} delayTime milliseconds to delay each item
@@ -41,11 +41,11 @@ DelaySink.prototype.dispose = function () {
 }
 
 DelaySink.prototype.event = function (t, x) {
-  this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
+  this.scheduler.delay(this.dt, propagateEventTask(x, this.sink))
 }
 
 DelaySink.prototype.end = function (t, x) {
-  this.scheduler.delay(this.dt, propagateEnd(x, this.sink))
+  this.scheduler.delay(this.dt, propagateEndTask(x, this.sink))
 }
 
 DelaySink.prototype.error = Pipe.prototype.error

--- a/src/combinator/delay.js
+++ b/src/combinator/delay.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagateEvent, propagateEnd } from '../scheduler/PropagateTask'
 
 /**
  * @param {Number} delayTime milliseconds to delay each item
@@ -41,11 +41,11 @@ DelaySink.prototype.dispose = function () {
 }
 
 DelaySink.prototype.event = function (t, x) {
-  this.scheduler.delay(this.dt, PropagateTask.event(x, this.sink))
+  this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
 }
 
 DelaySink.prototype.end = function (t, x) {
-  this.scheduler.delay(this.dt, PropagateTask.end(x, this.sink))
+  this.scheduler.delay(this.dt, propagateEnd(x, this.sink))
 }
 
 DelaySink.prototype.error = Pipe.prototype.error

--- a/src/combinator/errors.js
+++ b/src/combinator/errors.js
@@ -6,7 +6,7 @@ import Stream from '../Stream'
 import SafeSink from '../sink/SafeSink'
 import * as dispose from '../disposable/dispose'
 import * as tryEvent from '../source/tryEvent'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagateError } from '../scheduler/PropagateTask'
 
 /**
  * If stream encounters an error, recover and continue with items from stream
@@ -15,75 +15,76 @@ import PropagateTask from '../scheduler/PropagateTask'
  * @param {Stream} stream
  * @returns {Stream} new stream which will recover from an error by calling f
  */
-export function recoverWith (f, stream) {
-  return new Stream(new RecoverWith(f, stream.source))
-}
+export const recoverWith = (f, stream) =>
+  new Stream(new RecoverWith(f, stream.source))
 
 /**
  * Create a stream containing only an error
  * @param {*} e error value, preferably an Error or Error subtype
  * @returns {Stream} new stream containing only an error
  */
-export function throwError (e) {
-  return new Stream(new ErrorSource(e))
-}
+export const throwError = e =>
+  new Stream(new ErrorSource(e))
 
-function ErrorSource (e) {
-  this.value = e
-}
+class ErrorSource {
+  constructor (e) {
+    this.value = e
+  }
 
-ErrorSource.prototype.run = function (sink, scheduler) {
-  return scheduler.asap(new PropagateTask(runError, this.value, sink))
-}
-
-function runError (t, e, sink) {
-  sink.error(t, e)
-}
-
-function RecoverWith (f, source) {
-  this.f = f
-  this.source = source
-}
-
-RecoverWith.prototype.run = function (sink, scheduler) {
-  return new RecoverWithSink(this.f, this.source, sink, scheduler)
-}
-
-function RecoverWithSink (f, source, sink, scheduler) {
-  this.f = f
-  this.sink = new SafeSink(sink)
-  this.scheduler = scheduler
-  this.disposable = source.run(this, scheduler)
-}
-
-RecoverWithSink.prototype.event = function (t, x) {
-  tryEvent.tryEvent(t, x, this.sink)
-}
-
-RecoverWithSink.prototype.end = function (t, x) {
-  tryEvent.tryEnd(t, x, this.sink)
-}
-
-RecoverWithSink.prototype.error = function (t, e) {
-  var nextSink = this.sink.disable()
-
-  dispose.tryDispose(t, this.disposable, this.sink)
-  this._startNext(t, e, nextSink)
-}
-
-RecoverWithSink.prototype._startNext = function (t, x, sink) {
-  try {
-    this.disposable = this._continue(this.f, x, sink)
-  } catch (e) {
-    sink.error(t, e)
+  run (sink, scheduler) {
+    return scheduler.asap(propagateError(this.value, sink))
   }
 }
 
-RecoverWithSink.prototype._continue = function (f, x, sink) {
-  var stream = f(x)
-  return stream.source.run(sink, this.scheduler)
+class RecoverWith {
+  constructor (f, source) {
+    this.f = f
+    this.source = source
+  }
+
+  run (sink, scheduler) {
+    return new RecoverWithSink(this.f, this.source, sink, scheduler)
+  }
 }
 
-RecoverWithSink.prototype.dispose = function () {
-  return this.disposable.dispose()
+class RecoverWithSink {
+  constructor (f, source, sink, scheduler) {
+    this.f = f
+    this.sink = new SafeSink(sink)
+    this.scheduler = scheduler
+    this.disposable = source.run(this, scheduler)
+  }
+
+  event (t, x) {
+    tryEvent.tryEvent(t, x, this.sink)
+  }
+
+  end (t, x) {
+    tryEvent.tryEnd(t, x, this.sink)
+  }
+
+  error (t, e) {
+    const nextSink = this.sink.disable()
+
+    dispose.tryDispose(t, this.disposable, this.sink)
+    this._startNext(t, e, nextSink)
+  }
+
+  _startNext (t, x, sink) {
+    try {
+      this.disposable = this._continue(this.f, x, sink)
+    } catch (e) {
+      sink.error(t, e)
+    }
+  }
+
+  _continue (f, x, sink) {
+    const stream = f(x)
+    return stream.source.run(sink, this.scheduler)
+  }
+
+  dispose () {
+    return this.disposable.dispose()
+  }
 }
+

--- a/src/combinator/errors.js
+++ b/src/combinator/errors.js
@@ -6,7 +6,7 @@ import Stream from '../Stream'
 import SafeSink from '../sink/SafeSink'
 import * as dispose from '../disposable/dispose'
 import * as tryEvent from '../source/tryEvent'
-import { propagateError } from '../scheduler/PropagateTask'
+import { propagateErrorTask } from '../scheduler/PropagateTask'
 
 /**
  * If stream encounters an error, recover and continue with items from stream
@@ -32,7 +32,7 @@ class ErrorSource {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(propagateError(this.value, sink))
+    return scheduler.asap(propagateErrorTask(this.value, sink))
   }
 }
 

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagateEvent } from '../scheduler/PropagateTask'
 import Map from '../fusion/Map'
 
 /**
@@ -92,7 +92,7 @@ function DebounceSink (dt, source, sink, scheduler) {
 DebounceSink.prototype.event = function (t, x) {
   this._clearTimer()
   this.value = x
-  this.timer = this.scheduler.delay(this.dt, PropagateTask.event(x, this.sink))
+  this.timer = this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
 }
 
 DebounceSink.prototype.end = function (t, x) {

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -14,50 +14,45 @@ import Map from '../fusion/Map'
  * @param {Stream} stream
  * @returns {Stream}
  */
-export function throttle (period, stream) {
-  return new Stream(throttleSource(period, stream.source))
-}
+export const throttle = (period, stream) =>
+  new Stream(throttleSource(period, stream.source))
 
-function throttleSource (period, source) {
-  return source instanceof Map ? commuteMapThrottle(period, source)
+const throttleSource = (period, source) =>
+  source instanceof Map ? commuteMapThrottle(period, source)
     : source instanceof Throttle ? fuseThrottle(period, source)
     : new Throttle(period, source)
-}
 
-function commuteMapThrottle (period, source) {
-  return Map.create(source.f, throttleSource(period, source.source))
-}
+const commuteMapThrottle = (period, source) =>
+  Map.create(source.f, throttleSource(period, source.source))
 
-function fuseThrottle (period, source) {
-  return new Throttle(Math.max(period, source.period), source.source)
-}
+const fuseThrottle = (period, source) =>
+  new Throttle(Math.max(period, source.period), source.source)
 
-function Throttle (period, source) {
-  this.period = period
-  this.source = source
-}
+class Throttle {
+  constructor (period, source) {
+    this.period = period
+    this.source = source
+  }
 
-Throttle.prototype.run = function (sink, scheduler) {
-  return this.source.run(new ThrottleSink(this.period, sink), scheduler)
-}
-
-function ThrottleSink (period, sink) {
-  this.time = 0
-  this.period = period
-  this.sink = sink
-}
-
-ThrottleSink.prototype.event = function (t, x) {
-  if (t >= this.time) {
-    this.time = t + this.period
-    this.sink.event(t, x)
+  run (sink, scheduler) {
+    return this.source.run(new ThrottleSink(this.period, sink), scheduler)
   }
 }
 
-ThrottleSink.prototype.end = Pipe.prototype.end
+class ThrottleSink extends Pipe {
+  constructor (period, sink) {
+    super(sink)
+    this.time = 0
+    this.period = period
+  }
 
-ThrottleSink.prototype.error = Pipe.prototype.error
-
+  event (t, x) {
+    if (t >= this.time) {
+      this.time = t + this.period
+      this.sink.event(t, x)
+    }
+  }
+}
 /**
  * Wait for a burst of events to subside and emit only the last event in the burst
  * @param {Number} period events occuring more frequently than this
@@ -65,58 +60,62 @@ ThrottleSink.prototype.error = Pipe.prototype.error
  * @param {Stream} stream stream to debounce
  * @returns {Stream} new debounced stream
  */
-export function debounce (period, stream) {
-  return new Stream(new Debounce(period, stream.source))
+export const debounce = (period, stream) =>
+  new Stream(new Debounce(period, stream.source))
+
+class Debounce {
+  constructor (dt, source) {
+    this.dt = dt
+    this.source = source
+  }
+
+  run (sink, scheduler) {
+    return new DebounceSink(this.dt, this.source, sink, scheduler)
+  }
 }
 
-function Debounce (dt, source) {
-  this.dt = dt
-  this.source = source
-}
-
-Debounce.prototype.run = function (sink, scheduler) {
-  return new DebounceSink(this.dt, this.source, sink, scheduler)
-}
-
-function DebounceSink (dt, source, sink, scheduler) {
-  this.dt = dt
-  this.sink = sink
-  this.scheduler = scheduler
-  this.value = void 0
-  this.timer = null
-
-  var sourceDisposable = source.run(this, scheduler)
-  this.disposable = dispose.all([this, sourceDisposable])
-}
-
-DebounceSink.prototype.event = function (t, x) {
-  this._clearTimer()
-  this.value = x
-  this.timer = this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
-}
-
-DebounceSink.prototype.end = function (t, x) {
-  if (this._clearTimer()) {
-    this.sink.event(t, this.value)
+class DebounceSink {
+  constructor (dt, source, sink, scheduler) {
+    this.dt = dt
+    this.sink = sink
+    this.scheduler = scheduler
     this.value = void 0
+    this.timer = null
+
+    const sourceDisposable = source.run(this, scheduler)
+    this.disposable = dispose.all([this, sourceDisposable])
   }
-  this.sink.end(t, x)
-}
 
-DebounceSink.prototype.error = function (t, x) {
-  this._clearTimer()
-  this.sink.error(t, x)
-}
-
-DebounceSink.prototype.dispose = function () {
-  this._clearTimer()
-}
-
-DebounceSink.prototype._clearTimer = function () {
-  if (this.timer === null) {
-    return false
+  event (t, x) {
+    this._clearTimer()
+    this.value = x
+    this.timer = this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
   }
-  this.timer.dispose()
-  this.timer = null
-  return true
+
+  end (t, x) {
+    if (this._clearTimer()) {
+      this.sink.event(t, this.value)
+      this.value = void 0
+    }
+    this.sink.end(t, x)
+  }
+
+  error (t, x) {
+    this._clearTimer()
+    this.sink.error(t, x)
+  }
+
+  dispose () {
+    this._clearTimer()
+  }
+
+  _clearTimer () {
+    if (this.timer === null) {
+      return false
+    }
+    this.timer.dispose()
+    this.timer = null
+    return true
+  }
 }
+

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import { propagateEvent } from '../scheduler/PropagateTask'
+import { propagateEventTask } from '../scheduler/PropagateTask'
 import Map from '../fusion/Map'
 
 /**
@@ -89,7 +89,7 @@ class DebounceSink {
   event (t, x) {
     this._clearTimer()
     this.value = x
-    this.timer = this.scheduler.delay(this.dt, propagateEvent(x, this.sink))
+    this.timer = this.scheduler.delay(this.dt, propagateEventTask(x, this.sink))
   }
 
   end (t, x) {

--- a/src/combinator/scan.js
+++ b/src/combinator/scan.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagateEvent } from '../scheduler/PropagateTask'
 
 /**
  * Create a stream containing successive reduce results of applying f to
@@ -26,7 +26,7 @@ class Scan {
   }
 
   run (sink, scheduler) {
-    const d1 = scheduler.asap(PropagateTask.event(this.value, sink))
+    const d1 = scheduler.asap(propagateEvent(this.value, sink))
     const d2 = this.source.run(new ScanSink(this.f, this.value, sink), scheduler)
     return dispose.all([d1, d2])
   }

--- a/src/combinator/scan.js
+++ b/src/combinator/scan.js
@@ -5,7 +5,7 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as dispose from '../disposable/dispose'
-import { propagateEvent } from '../scheduler/PropagateTask'
+import { propagateEventTask } from '../scheduler/PropagateTask'
 
 /**
  * Create a stream containing successive reduce results of applying f to
@@ -26,7 +26,7 @@ class Scan {
   }
 
   run (sink, scheduler) {
-    const d1 = scheduler.asap(propagateEvent(this.value, sink))
+    const d1 = scheduler.asap(propagateEventTask(this.value, sink))
     const d2 = this.source.run(new ScanSink(this.f, this.value, sink), scheduler)
     return dispose.all([d1, d2])
   }

--- a/src/index.js
+++ b/src/index.js
@@ -187,4 +187,4 @@ export const newDefaultScheduler = () => _newScheduler(newClockTimer(), newTimel
 export { Scheduler, Timeline, ClockTimer }
 
 // export an implementation of Task used internally for third-party libraries
-export { default as PropagateTask } from './scheduler/PropagateTask'
+export { propagateEvent, propagateError, propagateEnd, propagate } from './scheduler/PropagateTask'

--- a/src/index.js
+++ b/src/index.js
@@ -187,4 +187,9 @@ export const newDefaultScheduler = () => _newScheduler(newClockTimer(), newTimel
 export { Scheduler, Timeline, ClockTimer }
 
 // export an implementation of Task used internally for third-party libraries
-export { propagateEvent, propagateError, propagateEnd, propagate } from './scheduler/PropagateTask'
+import { propagateTask as _propagateTask, propagateEventTask as _propagateEventTask, propagateErrorTask as _propagateErrorTask, propagateEndTask as _propagateEndTask } from './scheduler/PropagateTask'
+
+export const propagateTask = curry3(_propagateTask)
+export const propagateEventTask = curry2(_propagateEventTask)
+export const propagateErrorTask = curry2(_propagateErrorTask)
+export const propagateEndTask = curry2(_propagateEndTask)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -48,16 +48,16 @@ export type Timeline = {
 
 export type Scheduler = {
   now: () => Time,
-  asap: (task:Task) => ScheduledTask,
-  delay: (delay:Delay, task:Task) => ScheduledTask,
-  periodic: (period:Period, task:Task) => ScheduledTask,
-  schedule: (delay:Delay, period:Period, task:Task) => ScheduledTask,
-  cancel: (task:ScheduledTask) => void
+  asap: (task: Task) => ScheduledTask,
+  delay: (delay: Delay, task: Task) => ScheduledTask,
+  periodic: (period: Period, task: Task) => ScheduledTask,
+  schedule: (delay: Delay, period: Period, task: Task) => ScheduledTask,
+  cancel: (task: ScheduledTask) => void
 }
 
 export type Task = Disposable & {
-  run: (t:Time) => void,
-  error: (t:Time, e:Error) => void,
+  run: (t: Time) => void,
+  error: (t: Time, e:Error) => void,
 }
 
 export type ScheduledTask = Task
@@ -250,3 +250,16 @@ declare export function newClockTimer (): Timer
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler
 declare export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler
+
+export type PropagateTask<A> = Task & {
+  value: A,
+  sink: Sink<A>,
+  active: boolean
+}
+
+export type PropagateTaskRun<A> = (time: Time, value: A, sink: Sink<A>, task: PropagateTask<A>) => any
+
+declare export function propagateTask<A> (run: PropagateTaskRun<A>, value: A, sink: Sink<A>): PropagateTask<A>
+declare export function propagateEventTask<A> (value: A, sink: Sink<A>): PropagateTask<A>
+declare export function propagateErrorTask<E: Error> (e: E, sink: Sink<any>): PropagateTask<any>
+declare export function propagateEndTask (value: any, sink: Sink<any>): PropagateTask<any>

--- a/src/scheduler/PropagateTask.js
+++ b/src/scheduler/PropagateTask.js
@@ -4,13 +4,13 @@
 
 import fatal from '../fatalError'
 
-export const propagate = (run, value, sink) => new PropagateTask(run, value, sink)
+export const propagateTask = (run, value, sink) => new PropagateTask(run, value, sink)
 
-export const propagateEvent = (value, sink) => propagate(runEvent, value, sink)
+export const propagateEventTask = (value, sink) => propagateTask(runEvent, value, sink)
 
-export const propagateEnd = (value, sink) => propagate(runEnd, value, sink)
+export const propagateEndTask = (value, sink) => propagateTask(runEnd, value, sink)
 
-export const propagateError = (value, sink) => propagate(runError, value, sink)
+export const propagateErrorTask = (value, sink) => propagateTask(runError, value, sink)
 
 export class PropagateTask {
   constructor (run, value, sink) {

--- a/src/scheduler/PropagateTask.js
+++ b/src/scheduler/PropagateTask.js
@@ -4,51 +4,45 @@
 
 import fatal from '../fatalError'
 
-export default function PropagateTask (run, value, sink) {
-  this._run = run
-  this.value = value
-  this.sink = sink
-  this.active = true
-}
+export const propagate = (run, value, sink) => new PropagateTask(run, value, sink)
 
-PropagateTask.event = function (value, sink) {
-  return new PropagateTask(emit, value, sink)
-}
+export const propagateEvent = (value, sink) => propagate(runEvent, value, sink)
 
-PropagateTask.end = function (value, sink) {
-  return new PropagateTask(end, value, sink)
-}
+export const propagateEnd = (value, sink) => propagate(runEnd, value, sink)
 
-PropagateTask.error = function (value, sink) {
-  return new PropagateTask(error, value, sink)
-}
+export const propagateError = (value, sink) => propagate(runError, value, sink)
 
-PropagateTask.prototype.dispose = function () {
-  this.active = false
-}
-
-PropagateTask.prototype.run = function (t) {
-  if (!this.active) {
-    return
+export class PropagateTask {
+  constructor (run, value, sink) {
+    this._run = run
+    this.value = value
+    this.sink = sink
+    this.active = true
   }
-  this._run(t, this.value, this.sink)
-}
 
-PropagateTask.prototype.error = function (t, e) {
-  if (!this.active) {
-    return fatal(e)
+  dispose () {
+    this.active = false
   }
-  this.sink.error(t, e)
+
+  run (t) {
+    if (!this.active) {
+      return
+    }
+    const run = this._run
+    run(t, this.value, this.sink, this)
+  }
+
+  error (t, e) {
+    // TODO: Remove this check and just do this.sink.error(t, e)?
+    if (!this.active) {
+      return fatal(e)
+    }
+    this.sink.error(t, e)
+  }
 }
 
-function error (t, e, sink) {
-  sink.error(t, e)
-}
+const runEvent = (t, x, sink) => sink.event(t, x)
 
-function emit (t, x, sink) {
-  sink.event(t, x)
-}
+const runEnd = (t, x, sink) => sink.end(t, x)
 
-function end (t, x, sink) {
-  sink.end(t, x)
-}
+const runError = (t, e, sink) => sink.error(t, e)

--- a/src/source/core.js
+++ b/src/source/core.js
@@ -4,7 +4,7 @@
 
 import Stream from '../Stream'
 import * as dispose from '../disposable/dispose'
-import { propagate, propagateEnd } from '../scheduler/PropagateTask'
+import { propagateTask, propagateEndTask } from '../scheduler/PropagateTask'
 
 /**
  * Stream containing only x
@@ -19,7 +19,7 @@ class Just {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(propagate(runJust, this.value, sink))
+    return scheduler.asap(propagateTask(runJust, this.value, sink))
   }
 }
 
@@ -36,7 +36,7 @@ export const empty = () => EMPTY
 
 class EmptySource {
   run (sink, scheduler) {
-    const task = propagateEnd(undefined, sink)
+    const task = propagateEndTask(undefined, sink)
     scheduler.asap(task)
 
     return dispose.create(disposeEmpty, task)

--- a/src/source/core.js
+++ b/src/source/core.js
@@ -4,7 +4,7 @@
 
 import Stream from '../Stream'
 import * as dispose from '../disposable/dispose'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagate, propagateEnd } from '../scheduler/PropagateTask'
 
 /**
  * Stream containing only x
@@ -19,13 +19,13 @@ class Just {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(new PropagateTask(runJust, this.value, sink))
+    return scheduler.asap(propagate(runJust, this.value, sink))
   }
 }
 
 function runJust (t, x, sink) {
   sink.event(t, x)
-  sink.end(t, void 0)
+  sink.end(t, undefined)
 }
 
 /**
@@ -36,7 +36,7 @@ export const empty = () => EMPTY
 
 class EmptySource {
   run (sink, scheduler) {
-    const task = PropagateTask.end(void 0, sink)
+    const task = propagateEnd(undefined, sink)
     scheduler.asap(task)
 
     return dispose.create(disposeEmpty, task)

--- a/src/source/fromArray.js
+++ b/src/source/fromArray.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Stream from '../Stream'
-import { propagate } from '../scheduler/PropagateTask'
+import { propagateTask } from '../scheduler/PropagateTask'
 
 export const fromArray = a =>
   new Stream(new ArraySource(a))
@@ -14,7 +14,7 @@ class ArraySource {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(propagate(runProducer, this.array, sink))
+    return scheduler.asap(propagateTask(runProducer, this.array, sink))
   }
 }
 

--- a/src/source/fromArray.js
+++ b/src/source/fromArray.js
@@ -3,26 +3,27 @@
 /** @author John Hann */
 
 import Stream from '../Stream'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagate } from '../scheduler/PropagateTask'
 
-export function fromArray (a) {
-  return new Stream(new ArraySource(a))
+export const fromArray = a =>
+  new Stream(new ArraySource(a))
+
+class ArraySource {
+  constructor (a) {
+    this.array = a
+  }
+
+  run (sink, scheduler) {
+    return scheduler.asap(propagate(runProducer, this.array, sink))
+  }
 }
 
-function ArraySource (a) {
-  this.array = a
-}
-
-ArraySource.prototype.run = function (sink, scheduler) {
-  return scheduler.asap(new PropagateTask(runProducer, this.array, sink))
-}
-
-function runProducer (t, array, sink) {
-  for (var i = 0, l = array.length; i < l && this.active; ++i) {
+function runProducer (t, array, sink, task) {
+  for (let i = 0, l = array.length; i < l && task.active; ++i) {
     sink.event(t, array[i])
   }
 
-  this.active && end(t)
+  task.active && end(t)
 
   function end (t) {
     sink.end(t)

--- a/src/source/fromIterable.js
+++ b/src/source/fromIterable.js
@@ -2,7 +2,7 @@
 
 import Stream from '../Stream'
 import { getIterator } from '../iterable'
-import { propagate } from '../scheduler/PropagateTask'
+import { propagateTask } from '../scheduler/PropagateTask'
 
 export const fromIterable = iterable =>
   new Stream(new IterableSource(iterable))
@@ -13,7 +13,7 @@ class IterableSource {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(propagate(runProducer, getIterator(this.iterable), sink))
+    return scheduler.asap(propagateTask(runProducer, getIterator(this.iterable), sink))
   }
 }
 

--- a/src/source/fromIterable.js
+++ b/src/source/fromIterable.js
@@ -2,7 +2,7 @@
 
 import Stream from '../Stream'
 import { getIterator } from '../iterable'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagate } from '../scheduler/PropagateTask'
 
 export const fromIterable = iterable =>
   new Stream(new IterableSource(iterable))
@@ -13,17 +13,17 @@ class IterableSource {
   }
 
   run (sink, scheduler) {
-    return scheduler.asap(new PropagateTask(runProducer, getIterator(this.iterable), sink))
+    return scheduler.asap(propagate(runProducer, getIterator(this.iterable), sink))
   }
 }
 
-function runProducer (t, iterator, sink) {
+function runProducer (t, iterator, sink, task) {
   let r = iterator.next()
 
-  while (!r.done && this.active) {
+  while (!r.done && task.active) {
     sink.event(t, r.value)
     r = iterator.next()
   }
 
-  sink.end(t, r.value)
+  task.active && sink.end(t, r.value)
 }

--- a/src/source/periodic.js
+++ b/src/source/periodic.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Stream from '../Stream'
-import { propagateEvent } from '../scheduler/PropagateTask'
+import { propagateEventTask } from '../scheduler/PropagateTask'
 
 /**
  * Create a stream of events that occur at a regular period
@@ -20,6 +20,6 @@ class Periodic {
   }
 
   run (sink, scheduler) {
-    return scheduler.periodic(this.period, propagateEvent(undefined, sink))
+    return scheduler.periodic(this.period, propagateEventTask(undefined, sink))
   }
 }

--- a/src/source/periodic.js
+++ b/src/source/periodic.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Stream from '../Stream'
-import PropagateTask from '../scheduler/PropagateTask'
+import { propagateEvent } from '../scheduler/PropagateTask'
 
 /**
  * Create a stream of events that occur at a regular period
@@ -20,6 +20,6 @@ class Periodic {
   }
 
   run (sink, scheduler) {
-    return scheduler.periodic(this.period, PropagateTask.event(undefined, sink))
+    return scheduler.periodic(this.period, propagateEvent(undefined, sink))
   }
 }

--- a/test/helper/testEnv.js
+++ b/test/helper/testEnv.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Stream from '../../src/Stream'
-import { propagateEvent, propagateEnd } from '../../src/scheduler/PropagateTask'
+import { propagateEventTask, propagateEndTask } from '../../src/scheduler/PropagateTask'
 import Scheduler from '../../src/scheduler/Scheduler'
 import Timeline from '../../src/scheduler/Timeline'
 import VirtualTimer from './VirtualTimer'
@@ -55,12 +55,12 @@ class AtTimes {
 
 const runEvents = (events, sink, scheduler) => {
   const s = events.reduce(appendEvent(sink, scheduler), { tasks: [], time: 0 })
-  const end = scheduler.delay(s.time, propagateEnd(undefined, sink))
+  const end = scheduler.delay(s.time, propagateEndTask(undefined, sink))
   return createDispose(cancelAll, s.tasks.concat(end))
 }
 
 const appendEvent = (sink, scheduler) => (s, event) => {
-  const task = scheduler.delay(event.time, propagateEvent(event.value, sink))
+  const task = scheduler.delay(event.time, propagateEventTask(event.value, sink))
   return { tasks: s.tasks.concat(task), time: Math.max(s.time, event.time) }
 }
 

--- a/test/helper/testEnv.js
+++ b/test/helper/testEnv.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Stream from '../../src/Stream'
-import PropagateTask from '../../src/scheduler/PropagateTask'
+import { propagateEvent, propagateEnd } from '../../src/scheduler/PropagateTask'
 import Scheduler from '../../src/scheduler/Scheduler'
 import Timeline from '../../src/scheduler/Timeline'
 import VirtualTimer from './VirtualTimer'
@@ -55,12 +55,12 @@ class AtTimes {
 
 const runEvents = (events, sink, scheduler) => {
   const s = events.reduce(appendEvent(sink, scheduler), { tasks: [], time: 0 })
-  const end = scheduler.delay(s.time, PropagateTask.end(void 0, sink))
+  const end = scheduler.delay(s.time, propagateEnd(undefined, sink))
   return createDispose(cancelAll, s.tasks.concat(end))
 }
 
 const appendEvent = (sink, scheduler) => (s, event) => {
-  const task = scheduler.delay(event.time, PropagateTask.event(event.value, sink))
+  const task = scheduler.delay(event.time, propagateEvent(event.value, sink))
   return { tasks: s.tasks.concat(task), time: Math.max(s.time, event.time) }
 }
 


### PR DESCRIPTION
Remove the need to use thisArg in PropagateTask run functions by passing the task as an additional arg.  This also moves PropagateTask helpers from static methods to plain functions and switches PropagateTask to use named exports.  Convert touched sources to ES2015.

Close #19

AFFECTS: @most/core

ISSUES CLOSED: #19