### PR TITLE
chore(type-definitions): fix compiler errors

### DIFF
--- a/type-definitions/PropagateTask.d.ts
+++ b/type-definitions/PropagateTask.d.ts
@@ -15,7 +15,7 @@ export function propagateErrorTask(error: Error, sink: Sink<any>): PropagateTask
 export function propagateErrorTask(error: Error): (sink: Sink<any>) => PropagateTask<any>;
 
 export type PropagateTaskRun<A> =
-  (time: Time, value: A, sink: Sink<A>, task: PropagateTask<A>) => any
+  (time: number, value: A, sink: Sink<A>, task: PropagateTask<A>) => any
 
 export interface PropagateTask<A> extends Task {
   value: A;

--- a/type-definitions/combinator/zip.d.ts
+++ b/type-definitions/combinator/zip.d.ts
@@ -4,7 +4,7 @@ export function zip<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>, b: Stream<B>):
 export function zip<A, B, C, R>(fn: (a: A, b: B, c: C) => R, a: Stream<A>, b: Stream<B>, c: Stream<C>): Stream<R>;
 export function zip<A, B, C, D, R>( fn: (a: A, b: B, c: C, d: D) => R, a: Stream<A>, b: Stream<B>, c: Stream<C>, d: Stream<D>): Stream<R>;
 export function zip<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: Stream<A>, b: Stream<B>, c: Stream<C>, d: Stream<D>, e: Stream<E>): Stream<R>;
-export function zip<R>(f: (...args: any[]) => R, ...streams: Stream<any>[]);
+export function zip<R>(f: (...args: any[]) => R, ...streams: Stream<any>[]): Stream<R>;
 
 export function zipArray<A, B, R>(
   fn: (a: A, b: B) => R,

--- a/type-definitions/types.d.ts
+++ b/type-definitions/types.d.ts
@@ -39,7 +39,7 @@ export interface Timeline {
   add(scheduledTask: ScheduledTask): void;
   remove(scheduledTask: ScheduledTask): boolean;
   removeAll(f: (scheduledTask: ScheduledTask) => boolean): void;
-  runTasks(time: number, runTask: (task: ScheduledTask) => any);
+  runTasks(time: number, runTask: (task: ScheduledTask) => any): void;
 }
 
 export interface Task {


### PR DESCRIPTION
Fix some basic compiler errors that occur just by trying to use `@most/core` with typescript.