### PR TITLE
feat(withArrayValues): Add withArrayValues and zipArrayValues

### DIFF
--- a/packages/core/.flowconfig
+++ b/packages/core/.flowconfig
@@ -1,6 +1,8 @@
 [ignore]
 
 [include]
+../../node_modules
+test/
 test/flow/**/*.js
 dist/.*\.flow
 

--- a/packages/core/src/combinator/withArrayValues.js
+++ b/packages/core/src/combinator/withArrayValues.js
@@ -6,7 +6,7 @@ export const withArrayValues = (array, stream) =>
   zipArrayValues(keepLeft, array, stream)
 
 export const zipArrayValues = (f, array, stream) =>
-  array.length === 0
+  array.length === 0 || stream === empty()
     ? empty()
     : new ZipArrayValues(f, array, stream)
 

--- a/packages/core/src/combinator/withArrayValues.js
+++ b/packages/core/src/combinator/withArrayValues.js
@@ -1,0 +1,44 @@
+/** @license MIT License (c) copyright 2010-2017 original author or authors */
+import { empty } from '../source/core'
+import Pipe from '../sink/Pipe'
+
+export const withArrayValues = (array, stream) =>
+  zipArrayValues(keepLeft, array, stream)
+
+export const zipArrayValues = (f, array, stream) =>
+  array.length === 0
+    ? empty()
+    : new ZipArrayValues(f, array, stream)
+
+const keepLeft = (a, _) => a
+
+class ZipArrayValues {
+  constructor (f, values, source) {
+    this.f = f
+    this.values = values
+    this.source = source
+  }
+
+  run (sink, scheduler) {
+    return this.source.run(new ZipArrayValuesSink(this.f, this.values, sink), scheduler)
+  }
+}
+
+class ZipArrayValuesSink extends Pipe {
+  constructor (f, values, sink) {
+    super(sink)
+    this.f = f
+    this.values = values
+    this.index = 0
+  }
+
+  event (t, b) {
+    const f = this.f
+    this.sink.event(t, f(this.values[this.index], b))
+
+    this.index += 1
+    if (this.index >= this.values.length) {
+      this.sink.end(t)
+    }
+  }
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -9,6 +9,10 @@ export { fromArray } from './source/fromArray'
 
 export { fromIterable } from './source/fromIterable'
 
+import { zipArrayValues as _zipArrayValues, withArrayValues as _withArrayValues } from './combinator/withArrayValues'
+export const zipArrayValues = curry3(_zipArrayValues)
+export const withArrayValues = curry2(_withArrayValues)
+
 // -----------------------------------------------------------------------
 // Observing
 

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -125,6 +125,14 @@ declare export function zipArray <A, B, C, D, E, F, Z> (f: (A, B, C, D, E, F) =>
 declare export function zipArray <Z> (f: (...rest: Array<any>) => Z, ss: Array<Stream<any>>): Stream<Z>
 declare export function zipArray <Z> (f: (...rest: Array<any>) => Z): (ss: Array<Stream<any>>) => Stream<Z>
 
+declare export function withArrayValues <A> (a: Array<A>, s: Stream<any>): Stream<A>
+declare export function withArrayValues <A> (a: Array<A>): (s: Stream<any>) => Stream<A>
+
+declare export function zipArrayValues <A, B, C> (f: (A, B) => C, a: Array<A>, s: Stream<B>): Stream<C>
+declare export function zipArrayValues <A, B, C> (f: (A, B) => C): (a: Array<A>, s: Stream<B>) => Stream<C>
+declare export function zipArrayValues <A, B, C> (f: (A, B) => C, a: Array<A>): (s: Stream<B>) => Stream<C>
+declare export function zipArrayValues <A, B, C> (f: (A, B) => C): (a: Array<A>) => (s: Stream<B>) => Stream<C>
+
 declare export function filter <A> (p: (A) => boolean, s: Stream<A>): Stream<A>
 declare export function filter <A> (p: (A) => boolean): (s: Stream<A>) => Stream<A>
 

--- a/packages/core/test/combinator/withArrayValues-test.js
+++ b/packages/core/test/combinator/withArrayValues-test.js
@@ -10,7 +10,12 @@ import { collectEventsFor, makeEvents } from '../helper/testEnv'
 describe.only('withArrayValues', () => {
   describe('zipArrayValues', () => {
     it('should be empty for empty array', () => {
-      const s = zipArrayValues(fail, [], empty())
+      const s = zipArrayValues(fail, [], makeEvents(1, 1))
+      return collectEventsFor(1, s).then(eq([]))
+    })
+
+    it('should be empty for empty stream', () => {
+      const s = zipArrayValues(fail, [1, 2, 3], empty())
       return collectEventsFor(1, s).then(eq([]))
     })
 
@@ -42,11 +47,16 @@ describe.only('withArrayValues', () => {
 
   describe('withArrayValues', () => {
     it('should be empty for empty array', () => {
-      const s = withArrayValues([], empty())
+      const s = withArrayValues([], makeEvents(1, 1))
       return collectEventsFor(1, s).then(eq([]))
     })
 
-    it('should contain zipped values when more events than values', () => {
+    it('should be empty for empty stream', () => {
+      const s = withArrayValues([1, 2, 3], empty())
+      return collectEventsFor(1, s).then(eq([]))
+    })
+
+    it('should contain array values when more events than values', () => {
       const a = ['a', 'b', 'c']
       const n = a.length + 1
       const s = withArrayValues(a, makeEvents(1, n))
@@ -59,7 +69,7 @@ describe.only('withArrayValues', () => {
         ]))
     })
 
-    it('should contain zipped values when more values than events', () => {
+    it('should contain array values when more values than events', () => {
       const a = ['a', 'b', 'c']
       const n = a.length - 1
       const s = withArrayValues(a, makeEvents(1, n))

--- a/packages/core/test/combinator/withArrayValues-test.js
+++ b/packages/core/test/combinator/withArrayValues-test.js
@@ -1,0 +1,74 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq, fail } from '@briancavalier/assert'
+
+import { zipArrayValues, withArrayValues } from '../../src/combinator/withArrayValues'
+import { empty } from '../../src/source/core'
+
+import { collectEventsFor, makeEvents } from '../helper/testEnv'
+
+describe.only('withArrayValues', () => {
+  describe('zipArrayValues', () => {
+    it('should be empty for empty array', () => {
+      const s = zipArrayValues(fail, [], empty())
+      return collectEventsFor(1, s).then(eq([]))
+    })
+
+    it('should contain zipped values when more events than values', () => {
+      const a = ['a', 'b', 'c']
+      const n = a.length + 1
+      const s = zipArrayValues((a, b) => a + String(b), a, makeEvents(1, n))
+
+      return collectEventsFor(n, s)
+        .then(eq([
+          { time: 0, value: 'a0' },
+          { time: 1, value: 'b1' },
+          { time: 2, value: 'c2' }
+        ]))
+    })
+
+    it('should contain zipped values when more values than events', () => {
+      const a = ['a', 'b', 'c']
+      const n = a.length - 1
+      const s = zipArrayValues((a, b) => a + String(b), a, makeEvents(1, n))
+
+      return collectEventsFor(a.length, s)
+        .then(eq([
+          { time: 0, value: 'a0' },
+          { time: 1, value: 'b1' }
+        ]))
+    })
+  })
+
+  describe('withArrayValues', () => {
+    it('should be empty for empty array', () => {
+      const s = withArrayValues([], empty())
+      return collectEventsFor(1, s).then(eq([]))
+    })
+
+    it('should contain zipped values when more events than values', () => {
+      const a = ['a', 'b', 'c']
+      const n = a.length + 1
+      const s = withArrayValues(a, makeEvents(1, n))
+
+      return collectEventsFor(n, s)
+        .then(eq([
+          { time: 0, value: 'a' },
+          { time: 1, value: 'b' },
+          { time: 2, value: 'c' }
+        ]))
+    })
+
+    it('should contain zipped values when more values than events', () => {
+      const a = ['a', 'b', 'c']
+      const n = a.length - 1
+      const s = withArrayValues(a, makeEvents(1, n))
+
+      return collectEventsFor(a.length, s)
+        .then(eq([
+          { time: 0, value: 'a' },
+          { time: 1, value: 'b' }
+        ]))
+    })
+  })
+})

--- a/packages/core/test/combinator/withArrayValues-test.js
+++ b/packages/core/test/combinator/withArrayValues-test.js
@@ -7,7 +7,7 @@ import { empty } from '../../src/source/core'
 
 import { collectEventsFor, makeEvents } from '../helper/testEnv'
 
-describe.only('withArrayValues', () => {
+describe('withArrayValues', () => {
   describe('zipArrayValues', () => {
     it('should be empty for empty array', () => {
       const s = zipArrayValues(fail, [], makeEvents(1, 1))

--- a/packages/core/type-definitions/combinator/withArrayValues.d.ts
+++ b/packages/core/type-definitions/combinator/withArrayValues.d.ts
@@ -1,0 +1,6 @@
+import { Stream } from '@most/types'
+
+export function zipArrayValues <A, B, C> (f: (a: A, b: B) => C, a: Array<A>, s: Stream<B>): Stream<C>;
+export function zipArrayValues <A, B, C> (f: (a: A, b: B) => C): (a: Array<A>, s: Stream<B>) => Stream<C>;
+export function zipArrayValues <A, B, C> (f: (a: A, b: B) => C, a: Array<A>): (s: Stream<B>) => Stream<C>;
+export function zipArrayValues <A, B, C> (f: (a: A, b: B) => C): (a: Array<A>) => (s: Stream<B>) => Stream<C>;

--- a/packages/core/type-definitions/most.d.ts
+++ b/packages/core/type-definitions/most.d.ts
@@ -22,6 +22,7 @@ export * from './combinator/switch';
 export * from './combinator/timeslice';
 export * from './combinator/transform';
 export * from './combinator/zip';
+export * from './combinator/withArrayValues';
 
 export * from './source/core';
 export * from './source/newStream';


### PR DESCRIPTION
### Summary

This adds `withArrayValues` and `zipArrayValues` for mapping values from an array onto a stream.  In the case of `withArrayValues`, for each event, the stream provides the time component, and the array provides the value component.  Similarly for `zipArrayValues`, except it accepts a function to compute the value component from the array value and incoming event value.

### Other changes

- Run flow on the whole test dir.  It will only check files with `@flow` at the top, which for now, is only the new `withArrayValues-test.js`.  But, I like the idea of using unit tests also to check types.  Feedback welcome 😄 
  - Note that to do this, I had to give flow visibility into the top-level `node_modules` folder, since lerna is hoisting common dependencies (such as `mocha` and `@briancavalier/assert`) to the top level.

### Todo:

- [ ] deprecate `fromArray` and `fromIterable`