### PR TITLE
feat(core): POC Use stream-local relative time

### DIFF
--- a/packages/core/src/combinator/continueWith.js
+++ b/packages/core/src/combinator/continueWith.js
@@ -3,6 +3,7 @@
 /** @author John Hann */
 
 import Pipe from '../sink/Pipe'
+import RelativeSink from '../sink/RelativeSink'
 import { disposeOnce, tryDispose } from '@most/disposable'
 
 export const continueWith = (f, stream) =>
@@ -41,19 +42,20 @@ class ContinueWithSink extends Pipe {
     }
 
     tryDispose(t, this.disposable, this.sink)
+
     this._startNext(t, this.sink)
   }
 
   _startNext (t, sink) {
     try {
-      this.disposable = this._continue(this.f, sink)
+      this.disposable = this._continue(this.f, t, sink)
     } catch (e) {
       sink.error(t, e)
     }
   }
 
-  _continue (f, sink) {
-    return f().run(sink, this.scheduler)
+  _continue (f, t, sink) {
+    return f().run(new RelativeSink(t, sink), this.scheduler.relative(t))
   }
 
   dispose () {

--- a/packages/core/src/combinator/errors.js
+++ b/packages/core/src/combinator/errors.js
@@ -3,6 +3,7 @@
 /** @author John Hann */
 
 import SafeSink from '../sink/SafeSink'
+import RelativeSink from '../sink/RelativeSink'
 import { tryDispose } from '@most/disposable'
 import { tryEvent, tryEnd } from '../source/tryEvent'
 import { propagateErrorTask } from '../scheduler/PropagateTask'
@@ -66,20 +67,21 @@ class RecoverWithSink {
     const nextSink = this.sink.disable()
 
     tryDispose(t, this.disposable, this.sink)
+
     this._startNext(t, e, nextSink)
   }
 
   _startNext (t, x, sink) {
     try {
-      this.disposable = this._continue(this.f, x, sink)
+      this.disposable = this._continue(this.f, t, x, sink)
     } catch (e) {
       sink.error(t, e)
     }
   }
 
-  _continue (f, x, sink) {
+  _continue (f, t, x, sink) {
     const stream = f(x)
-    return stream.run(sink, this.scheduler)
+    return stream.run(new RelativeSink(t, sink), this.scheduler.relative(t))
   }
 
   dispose () {

--- a/packages/core/src/combinator/mergeConcurrently.js
+++ b/packages/core/src/combinator/mergeConcurrently.js
@@ -58,7 +58,7 @@ class Outer {
 
   _initInner (t, x) {
     const innerSink = new Inner(t, this, this.sink)
-    innerSink.disposable = mapAndRun(this.f, x, innerSink, this.scheduler)
+    innerSink.disposable = mapAndRun(this.f, t, x, innerSink, this.scheduler)
     this.current.add(innerSink)
   }
 
@@ -98,8 +98,8 @@ class Outer {
   }
 }
 
-const mapAndRun = (f, x, sink, scheduler) =>
-  f(x).run(sink, scheduler)
+const mapAndRun = (f, t, x, sink, scheduler) =>
+  f(x).run(sink, scheduler.relative(t))
 
 class Inner {
   constructor (time, outer, sink) {
@@ -111,15 +111,15 @@ class Inner {
   }
 
   event (t, x) {
-    this.sink.event(Math.max(t, this.time), x)
+    this.sink.event(t + this.time, x)
   }
 
   end (t) {
-    this.outer._endInner(Math.max(t, this.time), this)
+    this.outer._endInner(t + this.time, this)
   }
 
   error (t, e) {
-    this.outer.error(Math.max(t, this.time), e)
+    this.outer.error(t + this.time, e)
   }
 
   dispose () {

--- a/packages/core/src/combinator/switch.js
+++ b/packages/core/src/combinator/switch.js
@@ -32,9 +32,9 @@ class SwitchSink {
   }
 
   event (t, stream) {
-    this._disposeCurrent(t) // TODO: capture the result of this dispose
+    this._disposeCurrent(t)
     this.current = new Segment(t, Infinity, this, this.sink)
-    this.current.disposable = stream.run(this.current, this.scheduler)
+    this.current.disposable = stream.run(this.current, this.scheduler.relative(t))
   }
 
   end (t) {
@@ -91,21 +91,21 @@ class Segment {
   }
 
   event (t, x) {
-    if (t < this.max) {
-      this.sink.event(Math.max(t, this.min), x)
+    const time = Math.max(0, t + this.min)
+    if (time < this.max) {
+      this.sink.event(time, x)
     }
   }
 
   end (t) {
-    this.outer._endInner(Math.max(t, this.min), this)
+    this.outer._endInner(t + this.min, this)
   }
 
   error (t, e) {
-    this.outer._errorInner(Math.max(t, this.min), e, this)
+    this.outer._errorInner(t + this.min, e, this)
   }
 
   _dispose (t) {
-    this.max = t
-    tryDispose(t, this.disposable, this.sink)
+    tryDispose(t + this.min, this.disposable, this.sink)
   }
 }

--- a/packages/core/src/sink/RelativeSink.js
+++ b/packages/core/src/sink/RelativeSink.js
@@ -1,0 +1,18 @@
+export default class RelativeSink {
+  constructor (offset, sink) {
+    this.sink = sink
+    this.offset = offset
+  }
+
+  event (t, x) {
+    this.sink.event(t + this.offset, x)
+  }
+
+  error (t, e) {
+    this.sink.error(t + this.offset, e)
+  }
+
+  end (t) {
+    this.sink.end(t + this.offset)
+  }
+}

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -1,0 +1,31 @@
+
+export default class RelativeScheduler {
+  constructor(offset, scheduler) {
+    this.offset = offset
+    this.scheduler = scheduler
+  }
+
+  now () {
+    return this.scheduler.now() - this.offset
+  }
+
+  asap (task) {
+    return this.schedule(0, 0, -1, task)
+  }
+
+  delay (delay, task) {
+    return this.schedule(0, delay, -1, task)
+  }
+
+  periodic (period, task) {
+    return this.schedule(0, 0, period, task)
+  }
+
+  schedule (localOffset, delay, period, task) {
+    return this.scheduler.schedule(localOffset + this.offset, delay, period, task)
+  }
+
+  relative (offset) {
+    return new RelativeScheduler(offset + this.offset, this.scheduler)
+  }
+}

--- a/packages/scheduler/src/ScheduledTask.js
+++ b/packages/scheduler/src/ScheduledTask.js
@@ -1,22 +1,25 @@
 /** @license MIT License (c) copyright 2010-2017 original author or authors */
 
-export default function ScheduledTask (delay, period, task, scheduler) {
-  this.time = delay
-  this.period = period
-  this.task = task
-  this.scheduler = scheduler
-  this.active = true
-}
+export default class ScheduledTask {
+  constructor (time, localOffset, period, task, scheduler) {
+    this.time = time
+    this.localOffset = localOffset
+    this.period = period
+    this.task = task
+    this.scheduler = scheduler
+    this.active = true
+  }
 
-ScheduledTask.prototype.run = function () {
-  return this.task.run(this.time)
-}
+  run () {
+    return this.task.run(this.time - this.localOffset)
+  }
 
-ScheduledTask.prototype.error = function (e) {
-  return this.task.error(this.time, e)
-}
+  error (e) {
+    return this.task.error(this.time - this.localOffset, e)
+  }
 
-ScheduledTask.prototype.dispose = function () {
-  this.scheduler.cancel(this)
-  return this.task.dispose()
+  dispose () {
+    this.scheduler.cancel(this)
+    return this.task.dispose()
+  }
 }

--- a/packages/scheduler/src/index.js
+++ b/packages/scheduler/src/index.js
@@ -5,6 +5,7 @@ import { curry2 } from '@most/prelude'
 import Scheduler from './Scheduler'
 import Timeline from './Timeline'
 import ClockTimer from './ClockTimer'
+import RelativeScheduler from './RelativeScheduler'
 import { newPlatformClock } from './clock'
 
 export * from './clock'


### PR DESCRIPTION
This PR switches to stream-local time.  Each stream effectively has its own virtual clock that starts at zero.  In reality, they all share the same clock, but have an associated origin time offset.  This is done via a simple RelativeScheduler that wraps Scheduler and adds an offset.  Higher-order streams create a new RelativeScheduler, based on their own scheduler, with the appropriate time offset, and use that to run each inner stream.

Time must also be transformed "in the other direction", from local time to outer time, when merging inner events back to the outer sink.  RelativeSink implements that transform.  It was also convenient to implement it directly in the custom sinks used by mergeConcurrently and switchLatest.  It might be better to take the hit on creating a new extra RelativeSink wrappers rather than implement the transform in multiple places.

An analogy is 2d and 3d graphics, where it is desirable to be able to program objects, sprites, characters, etc. each of which has its own coordinate system, and there are transforms to and from local coord systems to scene/world coords (and finally to screen coords).

### Todo

- [ ] Types
- [ ] Unit tests
- [ ] Docs
