### PR TITLE
feat(core): Add stream local time

### DIFF
--- a/packages/core/src/combinator/continueWith.js
+++ b/packages/core/src/combinator/continueWith.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 import Pipe from '../sink/Pipe'
-import RelativeSink from '../sink/RelativeSink'
+import { runWithLocalTime } from '../scheduler/runWithLocalTime'
 import { disposeOnce, tryDispose } from '@most/disposable'
 
 export const continueWith = (f, stream) =>
@@ -55,7 +55,7 @@ class ContinueWithSink extends Pipe {
   }
 
   _continue (f, t, sink) {
-    return f().run(new RelativeSink(t, sink), this.scheduler.relative(t))
+    return runWithLocalTime(t, f(), sink, this.scheduler)
   }
 
   dispose () {

--- a/packages/core/src/combinator/continueWith.js
+++ b/packages/core/src/combinator/continueWith.js
@@ -3,6 +3,7 @@
 /** @author John Hann */
 
 import Pipe from '../sink/Pipe'
+import RelativeSink from '../sink/RelativeSink'
 import { disposeOnce, tryDispose } from '@most/disposable'
 
 export const continueWith = (f, stream) =>
@@ -41,19 +42,20 @@ class ContinueWithSink extends Pipe {
     }
 
     tryDispose(t, this.disposable, this.sink)
+
     this._startNext(t, this.sink)
   }
 
   _startNext (t, sink) {
     try {
-      this.disposable = this._continue(this.f, sink)
+      this.disposable = this._continue(this.f, t, sink)
     } catch (e) {
       sink.error(t, e)
     }
   }
 
-  _continue (f, sink) {
-    return f().run(sink, this.scheduler)
+  _continue (f, t, sink) {
+    return f().run(new RelativeSink(t, sink), this.scheduler.relative(t))
   }
 
   dispose () {

--- a/packages/core/src/combinator/errors.js
+++ b/packages/core/src/combinator/errors.js
@@ -3,10 +3,10 @@
 /** @author John Hann */
 
 import SafeSink from '../sink/SafeSink'
-import RelativeSink from '../sink/RelativeSink'
 import { tryDispose } from '@most/disposable'
 import { tryEvent, tryEnd } from '../source/tryEvent'
 import { propagateErrorTask } from '../scheduler/PropagateTask'
+import { runWithLocalTime } from '../scheduler/runWithLocalTime'
 
 /**
  * If stream encounters an error, recover and continue with items from stream
@@ -80,8 +80,7 @@ class RecoverWithSink {
   }
 
   _continue (f, t, x, sink) {
-    const stream = f(x)
-    return stream.run(new RelativeSink(t, sink), this.scheduler.relative(t))
+    return runWithLocalTime(t, f(x), sink, this.scheduler)
   }
 
   dispose () {

--- a/packages/core/src/combinator/errors.js
+++ b/packages/core/src/combinator/errors.js
@@ -3,6 +3,7 @@
 /** @author John Hann */
 
 import SafeSink from '../sink/SafeSink'
+import RelativeSink from '../sink/RelativeSink'
 import { tryDispose } from '@most/disposable'
 import { tryEvent, tryEnd } from '../source/tryEvent'
 import { propagateErrorTask } from '../scheduler/PropagateTask'
@@ -66,20 +67,21 @@ class RecoverWithSink {
     const nextSink = this.sink.disable()
 
     tryDispose(t, this.disposable, this.sink)
+
     this._startNext(t, e, nextSink)
   }
 
   _startNext (t, x, sink) {
     try {
-      this.disposable = this._continue(this.f, x, sink)
+      this.disposable = this._continue(this.f, t, x, sink)
     } catch (e) {
       sink.error(t, e)
     }
   }
 
-  _continue (f, x, sink) {
+  _continue (f, t, x, sink) {
     const stream = f(x)
-    return stream.run(sink, this.scheduler)
+    return stream.run(new RelativeSink(t, sink), this.scheduler.relative(t))
   }
 
   dispose () {

--- a/packages/core/src/combinator/mergeConcurrently.js
+++ b/packages/core/src/combinator/mergeConcurrently.js
@@ -58,7 +58,7 @@ class Outer {
 
   _initInner (t, x) {
     const innerSink = new Inner(t, this, this.sink)
-    innerSink.disposable = mapAndRun(this.f, x, innerSink, this.scheduler)
+    innerSink.disposable = mapAndRun(this.f, t, x, innerSink, this.scheduler)
     this.current.add(innerSink)
   }
 
@@ -98,8 +98,8 @@ class Outer {
   }
 }
 
-const mapAndRun = (f, x, sink, scheduler) =>
-  f(x).run(sink, scheduler)
+const mapAndRun = (f, t, x, sink, scheduler) =>
+  f(x).run(sink, scheduler.relative(t))
 
 class Inner {
   constructor (time, outer, sink) {
@@ -111,15 +111,15 @@ class Inner {
   }
 
   event (t, x) {
-    this.sink.event(Math.max(t, this.time), x)
+    this.sink.event(t + this.time, x)
   }
 
   end (t) {
-    this.outer._endInner(Math.max(t, this.time), this)
+    this.outer._endInner(t + this.time, this)
   }
 
   error (t, e) {
-    this.outer.error(Math.max(t, this.time), e)
+    this.outer.error(t + this.time, e)
   }
 
   dispose () {

--- a/packages/core/src/combinator/mergeConcurrently.js
+++ b/packages/core/src/combinator/mergeConcurrently.js
@@ -5,6 +5,7 @@
 import { disposeOnce, tryDispose } from '@most/disposable'
 import LinkedList from '../LinkedList'
 import { id as identity } from '@most/prelude'
+import { schedulerRelativeTo } from '@most/scheduler'
 
 export const mergeConcurrently = (concurrency, stream) =>
   mergeMapConcurrently(identity, concurrency, stream)
@@ -99,7 +100,7 @@ class Outer {
 }
 
 const mapAndRun = (f, t, x, sink, scheduler) =>
-  f(x).run(sink, scheduler.relative(t))
+  f(x).run(sink, schedulerRelativeTo(t, scheduler))
 
 class Inner {
   constructor (time, outer, sink) {

--- a/packages/core/src/combinator/switch.js
+++ b/packages/core/src/combinator/switch.js
@@ -3,6 +3,7 @@
 /** @author John Hann */
 
 import { disposeBoth, tryDispose } from '@most/disposable'
+import { schedulerRelativeTo } from '@most/scheduler'
 
 /**
  * Given a stream of streams, return a new stream that adopts the behavior
@@ -86,7 +87,7 @@ class Segment {
     this.max = max
     this.outer = outer
     this.sink = sink
-    this.disposable = stream.run(this, this.scheduler.relative(min))
+    this.disposable = source.run(this, schedulerRelativeTo(min, scheduler))
   }
 
   event (t, x) {

--- a/packages/core/src/combinator/switch.js
+++ b/packages/core/src/combinator/switch.js
@@ -86,25 +86,25 @@ class Segment {
     this.max = max
     this.outer = outer
     this.sink = sink
-    this.disposable = source.run(this, scheduler)
+    this.disposable = stream.run(this, this.scheduler.relative(min))
   }
 
   event (t, x) {
-    if (t < this.max) {
-      this.sink.event(Math.max(t, this.min), x)
+    const time = Math.max(0, t + this.min)
+    if (time < this.max) {
+      this.sink.event(time, x)
     }
   }
 
   end (t) {
-    this.outer._endInner(Math.max(t, this.min), this)
+    this.outer._endInner(t + this.min, this)
   }
 
   error (t, e) {
-    this.outer._errorInner(Math.max(t, this.min), e, this)
+    this.outer._errorInner(t + this.min, e, this)
   }
 
   _dispose (t) {
-    this.max = t
-    tryDispose(t, this.disposable, this.sink)
+    tryDispose(t + this.min, this.disposable, this.sink)
   }
 }

--- a/packages/core/src/scheduler/runWithLocalTime.js
+++ b/packages/core/src/scheduler/runWithLocalTime.js
@@ -1,0 +1,6 @@
+/** @license MIT License (c) copyright 2010-2017 original author or authors */
+
+import RelativeSink from '../sink/RelativeSink'
+
+export const runWithLocalTime = (origin, stream, sink, scheduler) =>
+  stream.run(new RelativeSink(origin, sink), scheduler.relative(origin, scheduler))

--- a/packages/core/src/scheduler/runWithLocalTime.js
+++ b/packages/core/src/scheduler/runWithLocalTime.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2010-2017 original author or authors */
 
 import RelativeSink from '../sink/RelativeSink'
+import { schedulerRelativeTo } from '@most/scheduler'
 
 export const runWithLocalTime = (origin, stream, sink, scheduler) =>
-  stream.run(new RelativeSink(origin, sink), scheduler.relative(origin, scheduler))
+  stream.run(new RelativeSink(origin, sink), schedulerRelativeTo(origin, scheduler))

--- a/packages/core/src/sink/RelativeSink.js
+++ b/packages/core/src/sink/RelativeSink.js
@@ -1,0 +1,18 @@
+export default class RelativeSink {
+  constructor (offset, sink) {
+    this.sink = sink
+    this.offset = offset
+  }
+
+  event (t, x) {
+    this.sink.event(t + this.offset, x)
+  }
+
+  error (t, e) {
+    this.sink.error(t + this.offset, e)
+  }
+
+  end (t) {
+    this.sink.end(t + this.offset)
+  }
+}

--- a/packages/scheduler/.flowconfig
+++ b/packages/scheduler/.flowconfig
@@ -3,7 +3,7 @@
 [include]
 ../../node_modules
 test/
-dist/.*\.flow
+src/
 
 [libs]
 

--- a/packages/scheduler/src/AbstractScheduler.js
+++ b/packages/scheduler/src/AbstractScheduler.js
@@ -1,0 +1,22 @@
+// AbstractScheduler should not be exposed publicly
+// Temporary mixin to reduce duplication between
+// Scheduler and RelativeScheduler.  Eventually,
+// the Scheduler interface will change and this
+// can be removed.
+export default class RelativeScheduler {
+  asap (task) {
+    return this.schedule(0, 0, -1, task)
+  }
+
+  delay (delay, task) {
+    return this.schedule(0, delay, -1, task)
+  }
+
+  periodic (period, task) {
+    return this.schedule(0, 0, period, task)
+  }
+
+  schedule (delay, period, task) {
+    return this.schedule(0, delay, period, task)
+  }
+}

--- a/packages/scheduler/src/AbstractScheduler.js
+++ b/packages/scheduler/src/AbstractScheduler.js
@@ -3,20 +3,20 @@
 // Scheduler and RelativeScheduler.  Eventually,
 // the Scheduler interface will change and this
 // can be removed.
-export default class RelativeScheduler {
+export default class AbstractScheduler {
   asap (task) {
-    return this.schedule(0, 0, -1, task)
+    return this.scheduleTask(0, 0, -1, task)
   }
 
   delay (delay, task) {
-    return this.schedule(0, delay, -1, task)
+    return this.scheduleTask(0, delay, -1, task)
   }
 
   periodic (period, task) {
-    return this.schedule(0, 0, period, task)
+    return this.scheduleTask(0, 0, period, task)
   }
 
   schedule (delay, period, task) {
-    return this.schedule(0, delay, period, task)
+    return this.scheduleTask(0, delay, period, task)
   }
 }

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -12,7 +12,7 @@ export default class RelativeScheduler extends AbstractScheduler {
   }
 
   scheduleTask (localOffset, delay, period, task) {
-    return this.scheduler.schedule(localOffset + this.offset, delay, period, task)
+    return this.scheduler.scheduleTask(localOffset + this.offset, delay, period, task)
   }
 
   relative (offset) {

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -1,22 +1,22 @@
 import AbstractScheduler from './AbstractScheduler'
 
 export default class RelativeScheduler extends AbstractScheduler {
-  constructor (offset, scheduler) {
+  constructor (origin, scheduler) {
     super()
-    this.offset = offset
+    this.origin = origin
     this.scheduler = scheduler
   }
 
   now () {
-    return this.scheduler.now() - this.offset
+    return this.scheduler.now() - this.origin
   }
 
   scheduleTask (localOffset, delay, period, task) {
-    return this.scheduler.scheduleTask(localOffset + this.offset, delay, period, task)
+    return this.scheduler.scheduleTask(localOffset + this.origin, delay, period, task)
   }
 
-  relative (offset) {
-    return new RelativeScheduler(offset + this.offset, this.scheduler)
+  relative (origin) {
+    return new RelativeScheduler(origin + this.origin, this.scheduler)
   }
 
   cancel (task) {

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -1,6 +1,8 @@
+import AbstractScheduler from './AbstractScheduler'
 
-export default class RelativeScheduler {
+export default class RelativeScheduler extends AbstractScheduler {
   constructor (offset, scheduler) {
+    super()
     this.offset = offset
     this.scheduler = scheduler
   }
@@ -9,19 +11,7 @@ export default class RelativeScheduler {
     return this.scheduler.now() - this.offset
   }
 
-  asap (task) {
-    return this.schedule(0, 0, -1, task)
-  }
-
-  delay (delay, task) {
-    return this.schedule(0, delay, -1, task)
-  }
-
-  periodic (period, task) {
-    return this.schedule(0, 0, period, task)
-  }
-
-  schedule (localOffset, delay, period, task) {
+  scheduleTask (localOffset, delay, period, task) {
     return this.scheduler.schedule(localOffset + this.offset, delay, period, task)
   }
 

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -1,0 +1,31 @@
+
+export default class RelativeScheduler {
+  constructor (offset, scheduler) {
+    this.offset = offset
+    this.scheduler = scheduler
+  }
+
+  now () {
+    return this.scheduler.now() - this.offset
+  }
+
+  asap (task) {
+    return this.schedule(0, 0, -1, task)
+  }
+
+  delay (delay, task) {
+    return this.schedule(0, delay, -1, task)
+  }
+
+  periodic (period, task) {
+    return this.schedule(0, 0, period, task)
+  }
+
+  schedule (localOffset, delay, period, task) {
+    return this.scheduler.schedule(localOffset + this.offset, delay, period, task)
+  }
+
+  relative (offset) {
+    return new RelativeScheduler(offset + this.offset, this.scheduler)
+  }
+}

--- a/packages/scheduler/src/RelativeScheduler.js
+++ b/packages/scheduler/src/RelativeScheduler.js
@@ -28,4 +28,12 @@ export default class RelativeScheduler {
   relative (offset) {
     return new RelativeScheduler(offset + this.offset, this.scheduler)
   }
+
+  cancel (task) {
+    return this.scheduler.cancel(task)
+  }
+
+  cancelAll (f) {
+    return this.scheduler.cancelAll(f)
+  }
 }

--- a/packages/scheduler/src/ScheduledTask.js
+++ b/packages/scheduler/src/ScheduledTask.js
@@ -1,22 +1,25 @@
 /** @license MIT License (c) copyright 2010-2017 original author or authors */
 
-export default function ScheduledTask (delay, period, task, scheduler) {
-  this.time = delay
-  this.period = period
-  this.task = task
-  this.scheduler = scheduler
-  this.active = true
-}
+export default class ScheduledTask {
+  constructor (time, localOffset, period, task, scheduler) {
+    this.time = time
+    this.localOffset = localOffset
+    this.period = period
+    this.task = task
+    this.scheduler = scheduler
+    this.active = true
+  }
 
-ScheduledTask.prototype.run = function () {
-  return this.task.run(this.time)
-}
+  run () {
+    return this.task.run(this.time - this.localOffset)
+  }
 
-ScheduledTask.prototype.error = function (e) {
-  return this.task.error(this.time, e)
-}
+  error (e) {
+    return this.task.error(this.time - this.localOffset, e)
+  }
 
-ScheduledTask.prototype.dispose = function () {
-  this.scheduler.cancel(this)
-  return this.task.dispose()
+  dispose () {
+    this.scheduler.cancel(this)
+    return this.task.dispose()
+  }
 }

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -1,11 +1,13 @@
 /** @license MIT License (c) copyright 2010-2017 original author or authors */
 
 import ScheduledTask from './ScheduledTask'
+import AbstractScheduler from './AbstractScheduler'
 import RelativeScheduler from './RelativeScheduler'
 import { runTask } from './task'
 
-export default class Scheduler {
+export default class Scheduler extends AbstractScheduler {
   constructor (timer, timeline) {
+    super()
     this.timer = timer
     this.timeline = timeline
 
@@ -19,19 +21,7 @@ export default class Scheduler {
     return this.timer.now()
   }
 
-  asap (task) {
-    return this.schedule(0, 0, -1, task)
-  }
-
-  delay (delay, task) {
-    return this.schedule(0, delay, -1, task)
-  }
-
-  periodic (period, task) {
-    return this.schedule(0, 0, period, task)
-  }
-
-  schedule (localOffset, delay, period, task) {
+  scheduleTask (localOffset, delay, period, task) {
     const time = this.now() + Math.max(0, delay)
     const st = new ScheduledTask(time, localOffset, period, task, this)
 

--- a/packages/scheduler/src/index.js
+++ b/packages/scheduler/src/index.js
@@ -5,7 +5,6 @@ import { curry2 } from '@most/prelude'
 import Scheduler from './Scheduler'
 import Timeline from './Timeline'
 import ClockTimer from './ClockTimer'
-import RelativeScheduler from './RelativeScheduler'
 import { newPlatformClock } from './clock'
 
 export * from './clock'

--- a/packages/scheduler/src/index.js
+++ b/packages/scheduler/src/index.js
@@ -5,6 +5,7 @@ import { curry2 } from '@most/prelude'
 import Scheduler from './Scheduler'
 import Timeline from './Timeline'
 import ClockTimer from './ClockTimer'
+import RelativeScheduler from './RelativeScheduler'
 import { newPlatformClock } from './clock'
 
 export * from './clock'

--- a/packages/scheduler/src/index.js
+++ b/packages/scheduler/src/index.js
@@ -8,6 +8,8 @@ import ClockTimer from './ClockTimer'
 import { newPlatformClock } from './clock'
 
 export * from './clock'
+export * from './schedule'
+export * from './relative'
 
 export const newScheduler = curry2((timer, timeline) => new Scheduler(timer, timeline))
 

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -31,7 +31,7 @@ declare export function delay (delay: Delay): (task: Task, scheduler: Scheduler)
 declare export function delay (delay: Delay, task: Task): (scheduler: Scheduler) => ScheduledTask
 declare export function delay (delay: Delay): (task: Task) => (scheduler: Scheduler) => ScheduledTask
 
-declare export function period (period: Period, task: Task, scheduler: Scheduler): ScheduledTask
-declare export function period (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask
-declare export function period (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask
-declare export function period (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask
+declare export function periodic (period: Period, task: Task, scheduler: Scheduler): ScheduledTask
+declare export function periodic (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask
+declare export function periodic (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask
+declare export function periodic (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type { Scheduler, Timeline, Timer, Time } from '@most/types'
+import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types'
 
 export type Clock = {
   now: () => Time
@@ -10,6 +10,9 @@ declare export function newScheduler (timer: Timer): (timeline: Timeline) => Sch
 
 declare export function newDefaultScheduler (): Scheduler
 
+declare export function schedulerRelativeTo (offset: Offset, scheduler: Scheduler): Scheduler
+declare export function schedulerRelativeTo (offset: Offset): (scheduler: Scheduler) => Scheduler
+
 declare export function newClockTimer (clock: Clock): Timer
 declare export function newTimeline (): Timeline
 
@@ -17,4 +20,18 @@ declare export function newPlatformClock (): Clock
 declare export function newPerformanceClock (): Clock
 declare export function newDateClock (): Clock
 declare export function newHRTimeClock (): Clock
+
 declare export function clockRelativeTo (clock: Clock): Clock
+
+declare export function asap (task: Task, scheduler: Scheduler): ScheduledTask
+declare export function asap (task: Task): (scheduler: Scheduler) => ScheduledTask
+
+declare export function delay (delay: Delay, task: Task, scheduler: Scheduler): ScheduledTask
+declare export function delay (delay: Delay): (task: Task, scheduler: Scheduler) => ScheduledTask
+declare export function delay (delay: Delay, task: Task): (scheduler: Scheduler) => ScheduledTask
+declare export function delay (delay: Delay): (task: Task) => (scheduler: Scheduler) => ScheduledTask
+
+declare export function period (period: Period, task: Task, scheduler: Scheduler): ScheduledTask
+declare export function period (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask
+declare export function period (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask
+declare export function period (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask

--- a/packages/scheduler/src/relative.js
+++ b/packages/scheduler/src/relative.js
@@ -1,0 +1,5 @@
+import RelativeScheduler from './RelativeScheduler'
+import { curry2 } from '@most/prelude'
+
+export const schedulerRelativeTo = curry2((offset, scheduler) =>
+  new RelativeScheduler(offset, scheduler))

--- a/packages/scheduler/src/schedule.js
+++ b/packages/scheduler/src/schedule.js
@@ -1,0 +1,15 @@
+import { curry2, curry3 } from '@most/prelude'
+
+// Schedule a task to run as soon as possible, but
+// not in the current call stack
+export const asap = curry2((task, scheduler) =>
+  delay(0, task, scheduler))
+
+// Schedule a task to run after a millisecond delay
+export const delay = curry3((delay, task, scheduler) =>
+  scheduler.schedule(0, delay, -1, task))
+
+// Schedule a task to run periodically, with the
+// first run starting asap
+export const periodic = curry3((period, task, scheduler) =>
+  scheduler.schedule(0, 0, period, task))

--- a/packages/scheduler/src/schedule.js
+++ b/packages/scheduler/src/schedule.js
@@ -3,13 +3,13 @@ import { curry2, curry3 } from '@most/prelude'
 // Schedule a task to run as soon as possible, but
 // not in the current call stack
 export const asap = curry2((task, scheduler) =>
-  delay(0, task, scheduler))
+  scheduler.asap(task))
 
 // Schedule a task to run after a millisecond delay
 export const delay = curry3((delay, task, scheduler) =>
-  scheduler.schedule(0, delay, -1, task))
+  scheduler.delay(delay, task))
 
 // Schedule a task to run periodically, with the
 // first run starting asap
 export const periodic = curry3((period, task, scheduler) =>
-  scheduler.schedule(0, 0, period, task))
+  scheduler.periodic(period, task))

--- a/packages/scheduler/test/AbstractScheduler-test.js
+++ b/packages/scheduler/test/AbstractScheduler-test.js
@@ -1,0 +1,79 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq, is, assert } from '@briancavalier/assert'
+import { noopTask } from './helper/FakeTask'
+import ScheduledTask from '../src/ScheduledTask'
+
+import AbstractScheduler from '../src/AbstractScheduler'
+
+class TestScheduler extends AbstractScheduler {
+  scheduleTask (localOffset, delay, period, task) {
+    return new ScheduledTask(localOffset + delay, localOffset, period, task, this)
+  }
+
+  now () {
+    return 0
+  }
+
+  cancel (task) {}
+  cancelAll (f) {}
+}
+
+const verifyScheduledTask = (time, period, task, scheduler, st) => {
+  eq(time, st.time)
+  eq(0, st.localOffset)
+  eq(period, st.period)
+  assert(st.active)
+  is(task, st.task)
+  is(scheduler, st.scheduler)
+}
+
+describe('AbstractScheduler', () => {
+  describe('asap', () => {
+    it('should schedule task with no delay, no period', () => {
+      const s = new TestScheduler()
+      const task = noopTask()
+
+      const st = s.asap(task)
+
+      verifyScheduledTask(0, -1, task, s, st)
+    })
+  })
+
+  describe('delay', () => {
+    it('should schedule task with expected delay, no period', () => {
+      const s = new TestScheduler()
+      const task = noopTask()
+      const delay = Math.random()
+
+      const st = s.delay(delay, task)
+
+      verifyScheduledTask(delay, -1, task, s, st)
+    })
+  })
+
+  describe('periodic', () => {
+    it('should schedule task with no delay, expected period', () => {
+      const s = new TestScheduler()
+      const task = noopTask()
+      const period = Math.random()
+
+      const st = s.periodic(period, task)
+
+      verifyScheduledTask(0, period, task, s, st)
+    })
+  })
+
+  describe('schedule', () => {
+    it('should schedule task with expected delay, expected period', () => {
+      const s = new TestScheduler()
+      const task = noopTask()
+      const delay = Math.random()
+      const period = Math.random()
+
+      const st = s.schedule(delay, period, task)
+
+      verifyScheduledTask(delay, period, task, s, st)
+    })
+  })
+})

--- a/packages/scheduler/test/RelativeScheduler-test.js
+++ b/packages/scheduler/test/RelativeScheduler-test.js
@@ -1,0 +1,107 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq, is, assert } from '@briancavalier/assert'
+import FakeScheduler from './helper/FakeScheduler'
+import { noopTask } from './helper/FakeTask'
+
+import RelativeScheduler from '../src/RelativeScheduler'
+
+describe('RelativeScheduler', () => {
+  describe('now', () => {
+    it('should have expected origin', () => {
+      const origin = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs = new RelativeScheduler(origin, s)
+
+      eq(time - origin, rs.now())
+    })
+  })
+
+  describe('scheduleTask', () => {
+    it('should schedule task relative to underlying scheduler', () => {
+      const origin = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs = new RelativeScheduler(origin, s)
+
+      const localOffset = Math.random()
+      const delay = Math.random()
+      const period = Math.random()
+      const task = noopTask()
+
+      const st = rs.scheduleTask(localOffset, delay, period, task)
+
+      eq(time + delay, st.time)
+      eq(localOffset + origin, st.localOffset)
+      eq(period, st.period)
+      assert(st.active)
+      is(s, st.scheduler)
+      is(task, st.task)
+    })
+  })
+
+  describe('relative', () => {
+    it('should create RelativeScheduler relative to original', () => {
+      const origin1 = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs1 = new RelativeScheduler(origin1, s)
+
+      const origin2 = Math.random()
+
+      const rs2 = rs1.relative(origin2)
+
+      eq(origin1 + origin2, rs2.origin)
+    })
+  })
+
+  describe('cancel', () => {
+    it('should set task active = false', () => {
+      const origin = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs = new RelativeScheduler(origin, s)
+
+      const localOffset = Math.random()
+      const delay = Math.random()
+      const period = Math.random()
+      const task = noopTask()
+
+      const st = rs.scheduleTask(localOffset, delay, period, task)
+
+      assert(st.active)
+
+      rs.cancel(st)
+
+      assert(!st.active)
+    })
+  })
+
+  describe('cancelAll', () => {
+    it('should set task active = false', () => {
+      const origin = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs = new RelativeScheduler(origin, s)
+
+      const localOffset = Math.random()
+      const delay = Math.random()
+      const period = Math.random()
+      const task = noopTask()
+
+      const st = rs.scheduleTask(localOffset, delay, period, task)
+
+      assert(st.active)
+
+      rs.cancelAll(task => st === task)
+
+      assert(!st.active)
+    })
+  })
+})

--- a/packages/scheduler/test/helper/FakeScheduler.js
+++ b/packages/scheduler/test/helper/FakeScheduler.js
@@ -1,0 +1,39 @@
+import AbstractScheduler from '../../src/AbstractScheduler'
+import ScheduledTask from '../../src/ScheduledTask'
+
+export default class FakeScheduler extends AbstractScheduler {
+  constructor (time) {
+    super()
+    this.time = time
+    this.tasks = []
+  }
+
+  now () {
+    return this.time
+  }
+
+  scheduleTask (localOffset, delay, period, task) {
+    const st = new ScheduledTask(this.time + delay, localOffset, period, task, this)
+    this.tasks.push(st)
+    return st
+  }
+
+  relative (offset) {
+    return this
+  }
+
+  cancel (task) {
+    // Set task to inactive if it's in the tasks array
+    task.active = task.active && !(this.tasks.indexOf(task) >= 0)
+  }
+
+  cancelAll (f) {
+    this.tasks = this.tasks.reduce((tasks, task) => {
+      if (f(task)) {
+        task.active = false
+        return tasks
+      }
+      return tasks.concat(task)
+    }, [])
+  }
+}

--- a/packages/scheduler/test/helper/FakeTask.js
+++ b/packages/scheduler/test/helper/FakeTask.js
@@ -1,0 +1,18 @@
+export class FakeTask {
+  constructor (run, error) {
+    this.run = run
+    this.error = error
+  }
+  run (t) {}
+  error (t, e) {
+    throw e
+  }
+}
+
+const noop = t => {}
+const rethrow = (t, e) => {
+  throw e
+}
+
+export const noopTask = () =>
+  new FakeTask(noop, rethrow)

--- a/packages/scheduler/test/relative-test.js
+++ b/packages/scheduler/test/relative-test.js
@@ -1,0 +1,20 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq } from '@briancavalier/assert'
+import FakeScheduler from './helper/FakeScheduler'
+
+import { schedulerRelativeTo } from '../src/relative'
+
+describe('relative', () => {
+  describe('schedulerRelativeTo', () => {
+    it('should create scheduler with origin relative to other scheduler', () => {
+      const origin = Math.random()
+      const time = 1 + Math.random()
+      const s = new FakeScheduler(time)
+
+      const rs = schedulerRelativeTo(origin, s)
+
+      eq(time - origin, rs.now())
+    })
+  })
+})

--- a/packages/scheduler/test/schedule-test.js
+++ b/packages/scheduler/test/schedule-test.js
@@ -1,46 +1,17 @@
 // @flow
 import { describe, it } from 'mocha'
 import { eq, is, assert } from '@briancavalier/assert'
-import AbstractScheduler from '../src/AbstractScheduler'
-import ScheduledTask from '../src/ScheduledTask'
+import FakeScheduler from './helper/FakeScheduler'
+import { noopTask } from './helper/FakeTask'
 
 import { asap, delay, periodic } from '../src/schedule'
-
-class FakeScheduler extends AbstractScheduler {
-  constructor (time) {
-    super()
-    this.time = time
-  }
-
-  now () {
-    return this.time
-  }
-
-  scheduleTask (localOffset, delay, period, task) {
-    return new ScheduledTask(this.time + delay, localOffset, period, task, this)
-  }
-
-  relative (offset) {
-    return this
-  }
-
-  cancel (task) {}
-  cancelAll (f) {}
-}
-
-class FakeTask {
-  run (t) {}
-  error (t, e) {
-    throw e
-  }
-}
 
 describe('schedule', () => {
   describe('asap', () => {
     it('should schedule a task at time 0', () => {
       const time = Math.random()
       const scheduler = new FakeScheduler(time)
-      const task = new FakeTask()
+      const task = noopTask()
 
       const st = asap(task, scheduler)
 
@@ -57,7 +28,7 @@ describe('schedule', () => {
     it('should schedule a task at delay time', () => {
       const time = Math.random()
       const scheduler = new FakeScheduler(time)
-      const task = new FakeTask()
+      const task = noopTask()
       const dt = Math.random()
 
       const st = delay(dt, task, scheduler)
@@ -75,7 +46,7 @@ describe('schedule', () => {
     it('should schedule a task at delay time', () => {
       const time = Math.random()
       const scheduler = new FakeScheduler(time)
-      const task = new FakeTask()
+      const task = noopTask()
       const period = Math.random()
 
       const st = periodic(period, task, scheduler)

--- a/packages/scheduler/test/schedule-test.js
+++ b/packages/scheduler/test/schedule-test.js
@@ -1,0 +1,47 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq, is, assert } from '@briancavalier/assert'
+import AbstractScheduler from '../src/AbstractScheduler'
+import ScheduledTask from '../src/ScheduledTask'
+
+import { asap } from '../src/schedule'
+
+class FakeScheduler extends AbstractScheduler {
+  now () {
+    return 0
+  }
+
+  scheduleTask (localOffset, delay, period, task) {
+    return new ScheduledTask(delay, localOffset, period, task, this)
+  }
+
+  relative (offset) {
+    return this
+  }
+
+  cancel (task) {}
+  cancelAll (f) {}
+}
+
+class FakeTask {
+  run (t) {}
+  error (t, e) {
+    throw e
+  }
+}
+
+describe('asap', () => {
+  it('should schedule a task at time 0', () => {
+    const scheduler = new FakeScheduler()
+    const task = new FakeTask()
+
+    const st = asap(task, scheduler)
+
+    eq(scheduler.now(), st.time)
+    eq(0, st.localOffset)
+    eq(-1, st.period)
+    is(task, st.task)
+    is(scheduler, st.scheduler)
+    assert(st.active)
+  })
+})

--- a/packages/scheduler/test/schedule-test.js
+++ b/packages/scheduler/test/schedule-test.js
@@ -4,15 +4,20 @@ import { eq, is, assert } from '@briancavalier/assert'
 import AbstractScheduler from '../src/AbstractScheduler'
 import ScheduledTask from '../src/ScheduledTask'
 
-import { asap } from '../src/schedule'
+import { asap, delay, periodic } from '../src/schedule'
 
 class FakeScheduler extends AbstractScheduler {
+  constructor (time) {
+    super()
+    this.time = time
+  }
+
   now () {
-    return 0
+    return this.time
   }
 
   scheduleTask (localOffset, delay, period, task) {
-    return new ScheduledTask(delay, localOffset, period, task, this)
+    return new ScheduledTask(this.time + delay, localOffset, period, task, this)
   }
 
   relative (offset) {
@@ -30,18 +35,57 @@ class FakeTask {
   }
 }
 
-describe('asap', () => {
-  it('should schedule a task at time 0', () => {
-    const scheduler = new FakeScheduler()
-    const task = new FakeTask()
+describe('schedule', () => {
+  describe('asap', () => {
+    it('should schedule a task at time 0', () => {
+      const time = Math.random()
+      const scheduler = new FakeScheduler(time)
+      const task = new FakeTask()
 
-    const st = asap(task, scheduler)
+      const st = asap(task, scheduler)
 
-    eq(scheduler.now(), st.time)
-    eq(0, st.localOffset)
-    eq(-1, st.period)
-    is(task, st.task)
-    is(scheduler, st.scheduler)
-    assert(st.active)
+      eq(scheduler.now(), st.time)
+      eq(0, st.localOffset)
+      eq(-1, st.period)
+      is(task, st.task)
+      is(scheduler, st.scheduler)
+      assert(st.active)
+    })
+  })
+
+  describe('delay', () => {
+    it('should schedule a task at delay time', () => {
+      const time = Math.random()
+      const scheduler = new FakeScheduler(time)
+      const task = new FakeTask()
+      const dt = Math.random()
+
+      const st = delay(dt, task, scheduler)
+
+      eq(scheduler.now() + dt, st.time)
+      eq(0, st.localOffset)
+      eq(-1, st.period)
+      is(task, st.task)
+      is(scheduler, st.scheduler)
+      assert(st.active)
+    })
+  })
+
+  describe('periodic', () => {
+    it('should schedule a task at delay time', () => {
+      const time = Math.random()
+      const scheduler = new FakeScheduler(time)
+      const task = new FakeTask()
+      const period = Math.random()
+
+      const st = periodic(period, task, scheduler)
+
+      eq(scheduler.now(), st.time)
+      eq(0, st.localOffset)
+      eq(period, st.period)
+      is(task, st.task)
+      is(scheduler, st.scheduler)
+      assert(st.active)
+    })
   })
 })

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -30,7 +30,7 @@ export function delay (delay: Delay): (task: Task, scheduler: Scheduler) => Sche
 export function delay (delay: Delay, task: Task): (scheduler: Scheduler) => ScheduledTask;
 export function delay (delay: Delay): (task: Task) => (scheduler: Scheduler) => ScheduledTask;
 
-export function period (period: Period, task: Task, scheduler: Scheduler): ScheduledTask;
-export function period (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask;
-export function period (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask;
-export function period (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask;
+export function periodic (period: Period, task: Task, scheduler: Scheduler): ScheduledTask;
+export function periodic (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask;
+export function periodic (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask;
+export function periodic (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask;

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -1,4 +1,4 @@
-import { Scheduler, Timeline, Timer, Time } from '@most/types';
+import { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types';
 
 export type Clock = {
   now: () => Time
@@ -9,6 +9,9 @@ export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler;
 
 export function newDefaultScheduler (): Scheduler;
 
+export function schedulerRelativeTo (offset: Offset, scheduler: Scheduler): Scheduler
+export function schedulerRelativeTo (offset: Offset): (scheduler: Scheduler) => Scheduler
+
 export function newClockTimer (clock: Clock): Timer;
 export function newTimeline (): Timeline;
 
@@ -16,4 +19,18 @@ export function newPlatformClock (): Clock;
 export function newPerformanceClock (): Clock;
 export function newDateClock (): Clock;
 export function newHRTimeClock (): Clock;
+
 export function clockRelativeTo (clock: Clock): Clock;
+
+export function asap (task: Task, scheduler: Scheduler): ScheduledTask;
+export function asap (task: Task): (scheduler: Scheduler) => ScheduledTask;
+
+export function delay (delay: Delay, task: Task, scheduler: Scheduler): ScheduledTask;
+export function delay (delay: Delay): (task: Task, scheduler: Scheduler) => ScheduledTask;
+export function delay (delay: Delay, task: Task): (scheduler: Scheduler) => ScheduledTask;
+export function delay (delay: Delay): (task: Task) => (scheduler: Scheduler) => ScheduledTask;
+
+export function period (period: Period, task: Task, scheduler: Scheduler): ScheduledTask;
+export function period (period: Period): (task: Task, scheduler: Scheduler) => ScheduledTask;
+export function period (period: Period, task: Task): (scheduler: Scheduler) => ScheduledTask;
+export function period (period: Period): (task: Task) => (scheduler: Scheduler) => ScheduledTask;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -24,12 +24,13 @@ export type Delay = number;
 // Span of time between time instants
 export type Period = number;
 
+// Relative offset between two clocks / schedulers
+export type Offset = number
+
 export interface Scheduler {
   now(): Time;
-  asap(task: Task): ScheduledTask;
-  delay(delay: Delay, task: Task): ScheduledTask;
-  periodic(period: Period, task: Task): ScheduledTask;
-  schedule(delay: Delay, period: Period, task: Task): ScheduledTask;
+  schedule(offset: Offset, delay: Delay, period: Period, task: Task): ScheduledTask;
+  relative(offset: Offset): Scheduler;
   cancel(task: ScheduledTask): void;
   cancelAll(predicate: (task: ScheduledTask) => boolean): void;
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -29,7 +29,11 @@ export type Offset = number
 
 export interface Scheduler {
   now(): Time;
-  schedule(offset: Offset, delay: Delay, period: Period, task: Task): ScheduledTask;
+  asap (task: Task): ScheduledTask;
+  delay (delay: Delay, task: Task): ScheduledTask;
+  periodic (period: Period, task: Task): ScheduledTask;
+  schedule (delay: Delay, period: Period, task: Task): ScheduledTask;
+  scheduleTask (offset: Offset, delay: Delay, period: Period, task: Task): ScheduledTask;
   relative(offset: Offset): Scheduler;
   cancel(task: ScheduledTask): void;
   cancelAll(predicate: (task: ScheduledTask) => boolean): void;

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -31,7 +31,11 @@ export type Offset = number
 
 export type Scheduler = {
   now: () => Time,
-  schedule: (Offset, Delay, Period, Task) => ScheduledTask,
+  asap: (Task) => ScheduledTask,
+  delay: (Delay, Task) => ScheduledTask,
+  periodic: (Period, Task) => ScheduledTask,
+  schedule: (Delay, Period, Task) => ScheduledTask,
+  scheduleTask: (Offset, Delay, Period, Task) => ScheduledTask,
   relative: (Offset) => Scheduler,
   cancel: (ScheduledTask) => void,
   cancelAll: ((ScheduledTask) => boolean) => void

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -26,12 +26,13 @@ export type Delay = number
 // Span of time between time instants
 export type Period = number
 
+// Relative offset between two clocks / schedulers
+export type Offset = number
+
 export type Scheduler = {
   now: () => Time,
-  asap: (Task) => ScheduledTask,
-  delay: (Delay, Task) => ScheduledTask,
-  periodic: (Period, Task) => ScheduledTask,
-  schedule: (Delay, Period, Task) => ScheduledTask,
+  schedule: (Offset, Delay, Period, Task) => ScheduledTask,
+  relative: (Offset) => Scheduler,
   cancel: (ScheduledTask) => void,
   cancelAll: ((ScheduledTask) => boolean) => void
 }


### PR DESCRIPTION
This PR switches to stream-local time.  Each stream effectively has its own virtual clock that starts at zero.  In reality, they all share the same clock, but have an associated origin time offset.  This is done via a simple RelativeScheduler that wraps Scheduler and adds an offset.  Higher-order streams create a new RelativeScheduler, based on their own scheduler, with the appropriate time offset, and use that to run each inner stream.

Time must also be transformed "in the other direction", from local time to outer time, when merging inner events back to the outer sink.  RelativeSink implements that transform.  It was also convenient to implement it directly in the custom sinks used by mergeConcurrently and switchLatest.  It might be better to take the hit on creating a new extra RelativeSink wrappers rather than implement the transform in multiple places.

An analogy is 2d and 3d graphics, where it is desirable to be able to program objects, sprites, characters, etc. each of which has its own coordinate system, and there are transforms to and from local coord systems to scene/world coords (and finally to screen coords).

### Todo

- [x] Types
- [x] Unit tests
- ~~Docs~~ Let's do a separate docs pass
