### PR TITLE
fix(clock): Call performance.now as a method. Add new RelativeClock

### DIFF
--- a/packages/scheduler/src/clock.js
+++ b/packages/scheduler/src/clock.js
@@ -28,10 +28,10 @@ export class HRTimeClock {
 export const relativeClock = clock =>
   new RelativeClock(clock, clock.now())
 
-export const newPerformanceNowClock = () =>
+export const newPerformanceClock = () =>
   relativeClock(performance)
 
-export const newDateNowClock = () =>
+export const newDateClock = () =>
   relativeClock(Date)
 
 export const newHRTimeClock = () =>
@@ -39,10 +39,10 @@ export const newHRTimeClock = () =>
 
 export const newPlatformClock = () => {
   if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
-    return newPerformanceNowClock()
+    return newPerformanceClock()
   } else if (typeof process !== 'undefined' && typeof process.hrtime === 'function') {
     return newHRTimeClock()
   }
 
-  return newDateNowClock()
+  return newDateClock()
 }

--- a/packages/scheduler/src/clock.js
+++ b/packages/scheduler/src/clock.js
@@ -25,14 +25,14 @@ export class HRTimeClock {
   }
 }
 
-export const relativeClock = clock =>
+export const clockRelativeTo = clock =>
   new RelativeClock(clock, clock.now())
 
 export const newPerformanceClock = () =>
-  relativeClock(performance)
+  clockRelativeTo(performance)
 
 export const newDateClock = () =>
-  relativeClock(Date)
+  clockRelativeTo(Date)
 
 export const newHRTimeClock = () =>
   new HRTimeClock(process.hrtime, process.hrtime())

--- a/packages/scheduler/src/clock.js
+++ b/packages/scheduler/src/clock.js
@@ -2,37 +2,37 @@
 
 /*global performance, process*/
 
-export class MillisecondClock {
-  constructor (now, origin) {
+export class RelativeClock {
+  constructor (clock, origin) {
     this.origin = origin
-    this._now = now
+    this.clock = clock
   }
 
   now () {
-    return this._now() - this.origin
+    return this.clock.now() - this.origin
   }
 }
 
 export class HRTimeClock {
   constructor (hrtime, origin) {
     this.origin = origin
-    this._hrtime = hrtime
+    this.hrtime = hrtime
   }
 
   now () {
-    const hrt = this._hrtime(this.origin)
+    const hrt = this.hrtime(this.origin)
     return (hrt[0] * 1e9 + hrt[1]) / 1e6
   }
 }
 
-export const millisecondClockFromNow = now =>
-  new MillisecondClock(now, now())
+export const relativeClock = clock =>
+  new RelativeClock(clock, clock.now())
 
 export const newPerformanceNowClock = () =>
-  millisecondClockFromNow(performance.now)
+  relativeClock(performance)
 
 export const newDateNowClock = () =>
-  millisecondClockFromNow(Date.now)
+  relativeClock(Date)
 
 export const newHRTimeClock = () =>
   new HRTimeClock(process.hrtime, process.hrtime())

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -17,4 +17,4 @@ declare export function newPlatformClock (): Clock
 declare export function newPerformanceClock (): Clock
 declare export function newDateClock (): Clock
 declare export function newHRTimeClock (): Clock
-declare export function relativeClock (clock: Clock): Clock
+declare export function clockRelativeTo (clock: Clock): Clock

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -14,7 +14,7 @@ declare export function newClockTimer (clock: Clock): Timer
 declare export function newTimeline (): Timeline
 
 declare export function newPlatformClock (): Clock
-declare export function newPerformanceNowClock (): Clock
-declare export function newDateNowClock (): Clock
+declare export function newPerformanceClock (): Clock
+declare export function newDateClock (): Clock
 declare export function newHRTimeClock (): Clock
 declare export function relativeClock (clock: Clock): Clock

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -1,10 +1,8 @@
 // @flow
 import type { Scheduler, Timeline, Timer, Time } from '@most/types'
 
-export type Now = () => Time
-
 export type Clock = {
-  now: Now
+  now: () => Time
 }
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler
@@ -16,7 +14,7 @@ declare export function newClockTimer (clock: Clock): Timer
 declare export function newTimeline (): Timeline
 
 declare export function newPlatformClock (): Clock
-declare export function millisecondClockFromNow (now: Now): Clock
 declare export function newPerformanceNowClock (): Clock
 declare export function newDateNowClock (): Clock
 declare export function newHRTimeClock (): Clock
+declare export function relativeClock (clock: Clock): Clock

--- a/packages/scheduler/test/clock-test.js
+++ b/packages/scheduler/test/clock-test.js
@@ -2,11 +2,11 @@
 import { describe, it } from 'mocha'
 import { eq } from '@briancavalier/assert'
 
-import { relativeClock, RelativeClock, HRTimeClock } from '../src/clock'
+import { clockRelativeTo, RelativeClock, HRTimeClock } from '../src/clock'
 
 describe('clock', () => {
   describe('RelativeClock', () => {
-    it('should be relative to origin clock', () => {
+    it('should be relative to origin time and clock', () => {
       const origin = Math.random()
       const time = Math.random()
       const baseClock = { now: () => time }
@@ -19,19 +19,19 @@ describe('clock', () => {
     })
   })
 
-  describe('relativeClock', () => {
+  describe('clockRelativeTo', () => {
     it('should be relative to origin clock', () => {
       let time = 0
       const baseClock = { now: () => time++ }
 
-      const c = relativeClock(baseClock)
+      const c = clockRelativeTo(baseClock)
 
       eq(1, c.now())
     })
   })
 
   describe('HRTimeClock', () => {
-    it('should be relative to origin', () => {
+    it('should be relative to origin time and clock', () => {
       const origin = [10, 100000000]
       const hrt = [12, 137000000]
 

--- a/packages/scheduler/test/clock-test.js
+++ b/packages/scheduler/test/clock-test.js
@@ -2,20 +2,31 @@
 import { describe, it } from 'mocha'
 import { eq } from '@briancavalier/assert'
 
-import { millisecondClockFromNow, MillisecondClock, HRTimeClock } from '../src/clock'
+import { relativeClock, RelativeClock, HRTimeClock } from '../src/clock'
 
 describe('clock', () => {
-  describe('MillisecondClock', () => {
-    it('should be relative to origin', () => {
+  describe('RelativeClock', () => {
+    it('should be relative to origin clock', () => {
       const origin = Math.random()
       const time = Math.random()
-      const now = () => time
+      const baseClock = { now: () => time }
 
       const expected = time - origin
 
-      const c = new MillisecondClock(now, origin)
+      const c = new RelativeClock(baseClock, origin)
 
       eq(expected, c.now())
+    })
+  })
+
+  describe('relativeClock', () => {
+    it('should be relative to origin clock', () => {
+      let time = 0
+      const baseClock = { now: () => time++ }
+
+      const c = relativeClock(baseClock)
+
+      eq(1, c.now())
     })
   })
 
@@ -30,14 +41,5 @@ describe('clock', () => {
       const c = new HRTimeClock(hrtime, origin)
       eq(2037, c.now())
     })
-  })
-
-  describe('millisecondClockFromNow', () => {
-    let time = 0
-    const now = () => time++
-
-    const c = millisecondClockFromNow(now)
-
-    eq(1, c.now())
   })
 })

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -13,7 +13,7 @@ export function newClockTimer (clock: Clock): Timer;
 export function newTimeline (): Timeline;
 
 export function newPlatformClock (): Clock;
-export function newPerformanceNowClock (): Clock;
-export function newDateNowClock (): Clock;
+export function newPerformanceClock (): Clock;
+export function newDateClock (): Clock;
 export function newHRTimeClock (): Clock;
 export function relativeClock (clock: Clock): Clock;

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -16,4 +16,4 @@ export function newPlatformClock (): Clock;
 export function newPerformanceClock (): Clock;
 export function newDateClock (): Clock;
 export function newHRTimeClock (): Clock;
-export function relativeClock (clock: Clock): Clock;
+export function clockRelativeTo (clock: Clock): Clock;

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -1,9 +1,7 @@
 import { Scheduler, Timeline, Timer, Time } from '@most/types';
 
-export type Now = () => Time;
-
 export type Clock = {
-  now: Now
+  now: () => Time
 };
 
 export function newScheduler (timer: Timer, timeline: Timeline): Scheduler;
@@ -15,7 +13,7 @@ export function newClockTimer (clock: Clock): Timer;
 export function newTimeline (): Timeline;
 
 export function newPlatformClock (): Clock;
-export function millisecondClockFromNow (now: Now): Clock;
 export function newPerformanceNowClock (): Clock;
 export function newDateNowClock (): Clock;
 export function newHRTimeClock (): Clock;
+export function relativeClock (clock: Clock): Clock;


### PR DESCRIPTION
Fix #69 
Close #71 

Consider `Date` and `performance` to be acceptable `Clock` types.   Add new RelativeClock that accepts any `Clock` and creates a new `Clock` relative to its current time.