### PR TITLE
fix(newStream): export newStream from index.js

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,6 +5,8 @@ export { just, empty, never } from './source/core'
 
 export { periodic } from './source/periodic'
 
+export { newStream } from './source/newStream'
+
 import { zipArrayValues as _zipArrayValues, withArrayValues as _withArrayValues } from './combinator/withArrayValues'
 export const zipArrayValues = curry3(_zipArrayValues)
 export const withArrayValues = curry2(_withArrayValues)


### PR DESCRIPTION
newStream declared in TypeScript defs but not matched by an actual export.