### PR TITLE
chore(coverage): Enable nyc coverage in all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ node_modules/
 .idea/
 *.iml
 .DS_Store
+.nyc_output/
 experiments/
+coverage/
 dist/
 docs/_build
 docs/_build_html

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
     "test:lint": "eslint --fix --ignore-path ../../.eslintignore src test",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
@@ -48,6 +48,7 @@
     "eslint": "^3.15.0",
     "flow-bin": "^0.47.0",
     "mocha": "^3.4.2",
+    "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^2.0.0",

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
     "test:lint": "eslint --fix --ignore-path ../../.eslintignore src test",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:flow",
@@ -47,6 +47,7 @@
     "eslint": "^3.15.0",
     "flow-bin": "^0.47.0",
     "mocha": "^3.4.2",
+    "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^2.0.0",

--- a/packages/prelude/package.json
+++ b/packages/prelude/package.json
@@ -17,7 +17,7 @@
     "prepublish": "npm run build",
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
     "test:lint": "eslint src test",
-    "test:unit": "nyc mocha -r buba/register",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot",
     "test:flow": "flow check"
   },
   "repository": {
@@ -37,7 +37,7 @@
     "cpy-cli": "^1.0.1",
     "flow-bin": "^0.47.0",
     "mocha": "^3.4.2",
-    "nyc": "^10.3.2",
+    "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0"
   }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
     "test:lint": "eslint --fix --ignore-path ../../.eslintignore src test",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
@@ -48,6 +48,7 @@
     "eslint": "^3.15.0",
     "flow-bin": "^0.47.0",
     "mocha": "^3.4.2",
+    "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^2.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,6 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
-    "flow-bin": "^0.47.0",
-    "nyc": "^11.0.2"
+    "flow-bin": "^0.47.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,6 +31,7 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
-    "flow-bin": "^0.47.0"
+    "flow-bin": "^0.47.0",
+    "nyc": "^11.0.2"
   }
 }


### PR DESCRIPTION
Coverage was enabled in `@most/prelude`, but not other packages.  This adds coverage reporting to the rest of the packages and updates nyc to the latest version.