### PR TITLE
fix(package.json): make package.json version match npm

### DIFF
--- a/packages/prelude/package.json
+++ b/packages/prelude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@most/prelude",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "prelude",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
During the most recent `lerna publish`, I selected patch version bump for `@most/prelude` and minor version bump for all others.  However, lerna still bumped the minor version when publishing `@most/prelude`.

This seems like a lerna bug, and I'll work on reporting it.  In the meantime, this PR updates `@most/prelude`'s package.json version to match [what is actually published in npm, 1.6.0](https://www.npmjs.com/package/@most/prelude).

<img width="285" alt="screen shot 2017-06-23 at 7 46 57 am" src="https://user-images.githubusercontent.com/90518/27481057-c727a272-57e8-11e7-85ce-392394e67c89.png">