### PR TITLE
feat(runWithLocalTime): avoid nesting RelativeSinks

### DIFF
--- a/packages/core/src/scheduler/runWithLocalTime.js
+++ b/packages/core/src/scheduler/runWithLocalTime.js
@@ -3,5 +3,18 @@
 import RelativeSink from '../sink/RelativeSink'
 import { schedulerRelativeTo } from '@most/scheduler'
 
+// Run a stream with its own localized clock
+// This transforms time from the provided scheduler's clock to a stream-local
+// clock (which starts at 0), and then *back* to the scheduler's clock before
+// propagating events to sink.  IOW, stream.run will see local times, and sink
+// will see scheduler times.
 export const runWithLocalTime = (origin, stream, sink, scheduler) =>
-  stream.run(new RelativeSink(origin, sink), schedulerRelativeTo(origin, scheduler))
+  stream.run(relativeSink(origin, sink), schedulerRelativeTo(origin, scheduler))
+
+// Accumulate offsets instead of nesting RelativeSinks, which can happen
+// with higher-order stream and combinators like continueWith when they're
+// applied recursively.
+export const relativeSink = (origin, sink) =>
+  sink instanceof RelativeSink
+    ? new RelativeSink(origin + sink.offset, sink.sink)
+    : new RelativeSink(origin, sink)


### PR DESCRIPTION
Accumulate RelativeSink offsets to avoid nesting.

I don't like `instanceof`, but in this case it feels like the right thing.  The alternative would be to require a new method (i.e. analogous to Scheduler's recently-added `relative` method) on all Sinks, which feels too annoying for people writing custom Sinks.  Alternatively, we could offer a superclass that provides the method, but I dislike coupling people's code to a superclass even more than I dislike `instanceof`.