### PR TITLE
feat(types): Add explicit covariance to allow custom types

### DIFF
--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -2,7 +2,7 @@
 import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types'
 
 export type Clock = {
-  +now: () => Time
+  now (): Time
 }
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -2,7 +2,7 @@
 import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types'
 
 export type Clock = {
-  now: () => Time
+  +now: () => Time
 }
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -6,18 +6,18 @@
 export type Time = number
 
 export type Stream<A> = {
-  run: (Sink<A>, Scheduler) => Disposable
+  +run: (Sink<A>, Scheduler) => Disposable
 }
 
 export type Sink<A> = {
-  event: (Time, A) => void,
-  end: (Time) => void,
-  error: (Time, Error) => void,
+  +event: (Time, A) => void,
+  +end: (Time) => void,
+  +error: (Time, Error) => void,
 }
 
 // Interface of a resource that can be disposed
 export type Disposable = {
-  dispose: () => void
+  +dispose: () => void
 }
 
 // Delay time offset
@@ -30,15 +30,15 @@ export type Period = number
 export type Offset = number
 
 export type Scheduler = {
-  now: () => Time,
-  asap: (Task) => ScheduledTask,
-  delay: (Delay, Task) => ScheduledTask,
-  periodic: (Period, Task) => ScheduledTask,
-  schedule: (Delay, Period, Task) => ScheduledTask,
-  scheduleTask: (Offset, Delay, Period, Task) => ScheduledTask,
-  relative: (Offset) => Scheduler,
-  cancel: (ScheduledTask) => void,
-  cancelAll: ((ScheduledTask) => boolean) => void
+  +now: () => Time,
+  +asap: (Task) => ScheduledTask,
+  +delay: (Delay, Task) => ScheduledTask,
+  +periodic: (Period, Task) => ScheduledTask,
+  +schedule: (Delay, Period, Task) => ScheduledTask,
+  +scheduleTask: (Offset, Delay, Period, Task) => ScheduledTask,
+  +relative: (Offset) => Scheduler,
+  +cancel: (ScheduledTask) => void,
+  +cancelAll: ((ScheduledTask) => boolean) => void
 }
 
 // Opaque handle vended by some platform-specific functions,
@@ -48,9 +48,9 @@ export type Handle = any
 // A Timer can schedule a function to run after
 // a particular delay
 export type Timer = {
-  now: () => Time,
-  setTimer: (() => any, Delay) => Handle,
-  clearTimer: (Handle) => void
+  +now: () => Time,
+  +setTimer: (() => any, Delay) => Handle,
+  +clearTimer: (Handle) => void
 }
 
 // Run a ScheduledTask
@@ -59,20 +59,20 @@ export type TaskRunner = (ScheduledTask) => any
 // A Timeline is a set of ScheduledTasks to be executed at
 // particular times
 export type Timeline = {
-  add: (ScheduledTask) => void,
-  remove: (ScheduledTask) => boolean,
-  removeAll: ((ScheduledTask) => boolean) => void,
-  isEmpty: () => boolean,
-  nextArrival: () => Time,
-  runTasks: (Time, TaskRunner) => void
+  +add: (ScheduledTask) => void,
+  +remove: (ScheduledTask) => boolean,
+  +removeAll: ((ScheduledTask) => boolean) => void,
+  +isEmpty: () => boolean,
+  +nextArrival: () => Time,
+  +runTasks: (Time, TaskRunner) => void
 }
 
 export type Task = Disposable & {
-  run: (Time) => void,
-  error: (Time, Error) => void,
+  +run: (Time) => void,
+  +error: (Time, Error) => void,
 }
 
 export type ScheduledTask = Disposable & {
-  run: () => void,
-  error: (Error) => void,
+  +run: () => void,
+  +error: (Error) => void,
 }

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -10,7 +10,7 @@ export type Stream<A> = {
 }
 
 export type Sink<A> = {
-  event (Time, a: A): void,
+  event (Time, A): void,
   end (Time): void,
   error (Time, Error): void,
 }

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -6,18 +6,18 @@
 export type Time = number
 
 export type Stream<A> = {
-  +run: (Sink<A>, Scheduler) => Disposable
+  run (Sink<A>, Scheduler): Disposable
 }
 
 export type Sink<A> = {
-  +event: (Time, A) => void,
-  +end: (Time) => void,
-  +error: (Time, Error) => void,
+  event (Time, a: A): void,
+  end (Time): void,
+  error (Time, Error): void,
 }
 
 // Interface of a resource that can be disposed
 export type Disposable = {
-  +dispose: () => void
+  dispose (): void
 }
 
 // Delay time offset
@@ -30,15 +30,15 @@ export type Period = number
 export type Offset = number
 
 export type Scheduler = {
-  +now: () => Time,
-  +asap: (Task) => ScheduledTask,
-  +delay: (Delay, Task) => ScheduledTask,
-  +periodic: (Period, Task) => ScheduledTask,
-  +schedule: (Delay, Period, Task) => ScheduledTask,
-  +scheduleTask: (Offset, Delay, Period, Task) => ScheduledTask,
-  +relative: (Offset) => Scheduler,
-  +cancel: (ScheduledTask) => void,
-  +cancelAll: ((ScheduledTask) => boolean) => void
+  now (): Time,
+  asap (Task): ScheduledTask,
+  delay (Delay, Task): ScheduledTask,
+  periodic (Period, Task): ScheduledTask,
+  schedule (Delay, Period, Task): ScheduledTask,
+  scheduleTask (Offset, Delay, Period, Task): ScheduledTask,
+  relative (Offset): Scheduler,
+  cancel (ScheduledTask): void,
+  cancelAll ((ScheduledTask) => boolean): void
 }
 
 // Opaque handle vended by some platform-specific functions,
@@ -48,9 +48,9 @@ export type Handle = any
 // A Timer can schedule a function to run after
 // a particular delay
 export type Timer = {
-  +now: () => Time,
-  +setTimer: (() => any, Delay) => Handle,
-  +clearTimer: (Handle) => void
+  now (): Time,
+  setTimer (() => any, Delay): Handle,
+  clearTimer (Handle): void
 }
 
 // Run a ScheduledTask
@@ -59,20 +59,20 @@ export type TaskRunner = (ScheduledTask) => any
 // A Timeline is a set of ScheduledTasks to be executed at
 // particular times
 export type Timeline = {
-  +add: (ScheduledTask) => void,
-  +remove: (ScheduledTask) => boolean,
-  +removeAll: ((ScheduledTask) => boolean) => void,
-  +isEmpty: () => boolean,
-  +nextArrival: () => Time,
-  +runTasks: (Time, TaskRunner) => void
+  add (ScheduledTask): void,
+  remove (ScheduledTask): boolean,
+  removeAll ((ScheduledTask) => boolean): void,
+  isEmpty (): boolean,
+  nextArrival (): Time,
+  runTasks (Time, TaskRunner): void
 }
 
 export type Task = Disposable & {
-  +run: (Time) => void,
-  +error: (Time, Error) => void,
+  run (Time): void,
+  error (Time, Error): void,
 }
 
 export type ScheduledTask = Disposable & {
-  +run: () => void,
-  +error: (Error) => void,
+  run (): void,
+  error (Error): void,
 }


### PR DESCRIPTION
It seems like this should be fine, since all the types line up visually.

```js
class NullSink {
  event (t: Time, x: any): void {}
  end (t: Time): void {}
  error (t: Time, e: Error): void {}
}

const nullSink: Sink<any> = new NullSink()
```

It isn't.  Flow considers object properties to be _invariant_ by default (See [Property Invariance here](https://flow.org/blog/2016/10/04/Property-Variance/). I'm still not sure exactly _why_ prototype properties violate the invariance rule, but they do:

```
src/split.js:16
 16: const nullSink: Sink<any> = new NullSink()
                                 ^^^^^^^^^^^^^^ NullSink. Covariant property `error` incompatible with invariant use in
 16: const nullSink: Sink<any> = new NullSink()
                     ^^^^^^^^^ object type
```

This PR adds explicit covariance for the properties of core types, to allow prototype properties satisfying core types, like the above, to type check.

<img width="665" alt="screen shot 2017-07-11 at 7 19 43 am" src="https://user-images.githubusercontent.com/90518/28066062-61a432ba-6609-11e7-9e10-044bd1eaaa20.png">
