### PR TITLE
fix(at): export at

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,9 +1,10 @@
 /** @license MIT License (c) copyright 2016 original author or authors */
 import { curry2, curry3 } from '@most/prelude'
 
-export { now } from './source/now'
 export { empty } from './source/empty'
 export { never } from './source/never'
+export { now } from './source/now'
+export { at } from './source/at'
 
 export { periodic } from './source/periodic'
 


### PR DESCRIPTION
The type definitions were exporting `at`, but it was missing from the actual JS exports.  This PR adds it to the JS exports.