### PR TITLE
fix(skipAfter): export skipAfter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -332,6 +332,8 @@ takeWhile :: (a -> bool) -> Stream a -> Stream a
 
 skipWhile :: (a -> bool) -> Stream a -> Stream a
 
+skipAfter :: (a -> bool) -> Stream a -> Stream a
+
 until :: Stream * -> Stream a -> Stream a
 
 since :: Stream * -> Stream a -> Stream a

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -120,13 +120,14 @@ export const skipRepeatsWith = curry2(_skipRepeatsWith)
 // -----------------------------------------------------------------------
 // Slicing
 
-import { take as _take, skip as _skip, slice as _slice, takeWhile as _takeWhile, skipWhile as _skipWhile } from './combinator/slice'
+import { take as _take, skip as _skip, slice as _slice, takeWhile as _takeWhile, skipWhile as _skipWhile, skipAfter as _skipAfter } from './combinator/slice'
 
 export const take = curry2(_take)
 export const skip = curry2(_skip)
 export const slice = curry3(_slice)
 export const takeWhile = curry2(_takeWhile)
 export const skipWhile = curry2(_skipWhile)
+export const skipAfter = curry2(_skipAfter)
 
 // -----------------------------------------------------------------------
 // Time slicing


### PR DESCRIPTION
Add skipAfter to JS exports.  The types were there, but the function wasn't exported.  Added a doc reminder, too.