### PR TITLE
refactor(PropagateTask): remove now-unused  arg from PropagateTaskRun

### DIFF
--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -203,7 +203,7 @@ export type PropagateTask<A> = Task & {
   active: boolean
 }
 
-export type PropagateTaskRun<A> = (time: Time, value: A, sink: Sink<A>, task: PropagateTask<A>) => any
+export type PropagateTaskRun<A> = (time: Time, value: A, sink: Sink<A>) => any
 
 declare export function propagateTask<A> (run: PropagateTaskRun<A>, value: A, sink: Sink<A>): PropagateTask<A>
 declare export function propagateEventTask<A> (value: A, sink: Sink<A>): PropagateTask<A>

--- a/packages/core/src/scheduler/PropagateTask.js
+++ b/packages/core/src/scheduler/PropagateTask.js
@@ -29,7 +29,7 @@ export class PropagateTask {
       return
     }
     const run = this._run
-    run(t, this.value, this.sink, this)
+    run(t, this.value, this.sink)
   }
 
   error (t, e) {

--- a/packages/core/type-definitions/PropagateTask.d.ts
+++ b/packages/core/type-definitions/PropagateTask.d.ts
@@ -14,7 +14,7 @@ export function propagateErrorTask(error: Error, sink: Sink<any>): PropagateTask
 export function propagateErrorTask(error: Error): (sink: Sink<any>) => PropagateTask<any>;
 
 export type PropagateTaskRun<A> =
-  (time: number, value: A, sink: Sink<A>, task: PropagateTask<A>) => any
+  (time: number, value: A, sink: Sink<A>) => any
 
 export interface PropagateTask<A> extends Task {
   value: A;


### PR DESCRIPTION
AFAICT, the only usage of this was in `fromArray` and `fromIterable`.  Since those were removed, I think we can stop passing the task itself (which was always kind of a hack, anyway) to the run function.