### PR TITLE
fix(slice): Port fix from cujojs/most#468, simplify SettableDisposable

### DIFF
--- a/packages/core/src/disposable/SettableDisposable.js
+++ b/packages/core/src/disposable/SettableDisposable.js
@@ -1,14 +1,9 @@
-/** @license MIT License (c) copyright 2010-2016 original author or authors */
+/** @license MIT License (c) copyright 2010-2017 original author or authors */
 
 export default class SettableDisposable {
   constructor () {
-    this.disposable = void 0
+    this.disposable = undefined
     this.disposed = false
-    this._resolve = void 0
-
-    this.result = new Promise(resolve => {
-      this._resolve = resolve
-    })
   }
 
   setDisposable (disposable) {
@@ -19,21 +14,19 @@ export default class SettableDisposable {
     this.disposable = disposable
 
     if (this.disposed) {
-      this._resolve(disposable.dispose())
+      disposable.dispose()
     }
   }
 
   dispose () {
     if (this.disposed) {
-      return this.result
+      return
     }
 
     this.disposed = true
 
     if (this.disposable !== void 0) {
-      this.result = this.disposable.dispose()
+      this.disposable.dispose()
     }
-
-    return this.result
   }
 }

--- a/packages/core/test/disposable/SettableDisposable-test.js
+++ b/packages/core/test/disposable/SettableDisposable-test.js
@@ -1,42 +1,44 @@
 import { describe, it } from 'mocha'
-import { throws, is } from '@briancavalier/assert'
+import { throws, assert } from '@briancavalier/assert'
 
 import { default as SettableDisposable } from '../../src/disposable/SettableDisposable'
 
-describe('SettableDisposable', function () {
-  it('should allow setDisposable before dispose', function () {
-    var d = new SettableDisposable()
-    var data = {}
+const testDisposable = () => ({
+  disposed: false,
+  dispose () {
+    this.disposed = true
+  }
+})
 
-    d.setDisposable({
-      dispose: function () { return data }
-    })
+describe('SettableDisposable', () => {
+  it('should allow setDisposable before dispose', () => {
+    const sd = new SettableDisposable()
+    const d = testDisposable()
 
-    var x = d.dispose()
+    sd.setDisposable(d)
+    sd.dispose()
 
-    is(data, x)
+    assert(d.disposed)
   })
 
-  it('should allow setDisposable after dispose', function () {
-    var d = new SettableDisposable()
-    var data = {}
+  it('should allow setDisposable after dispose', () => {
+    const sd = new SettableDisposable()
+    const d = testDisposable()
 
-    var p = d.dispose()
+    sd.dispose()
 
-    d.setDisposable({
-      dispose: function () { return data }
-    })
+    sd.setDisposable(d)
 
-    return p.then(is(data))
+    assert(d.disposed)
   })
 
-  it('should allow setDisposable at most once', function () {
-    var d = new SettableDisposable()
+  it('should allow setDisposable at most once', () => {
+    const d = new SettableDisposable()
 
-    d.setDisposable({})
+    d.setDisposable(testDisposable())
 
     throws(() => {
-      d.setDisposable({})
+      d.setDisposable(testDisposable())
     })
   })
 })


### PR DESCRIPTION
Port fix from cujojs/most#468, simplify SettableDisposable.  SettableDisposable was a straggler and still used promises.  This removes the promise usage.  One slightly odd thing, is that this makes the timing of the underlying disposal invisible.  That's probably fine, but let me know if you see any potential problems with it.