### PR TITLE
docs(api): Expand API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1143,120 +1143,15 @@ Create a :ref:`Task` that can be scheduled to propagate an error to a :ref:`Sink
 @most/scheduler
 ---------------
 
-.. _newScheduler:
+.. _Scheduling Tasks:
 
-newScheduler
-^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newScheduler :: Timer -> Timeline -> Scheduler
-
-Create a new scheduler that uses the provided :ref:`Timer` and :ref:`Timeline` for scheduling tasks.
-
-.. _newDefaultScheduler:
-
-newDefaultScheduler
-^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newDefaultScheduler :: () -> Scheduler
-
-Create a new Scheduler that uses a default platform-specific :ref:`Timer` and new, empty :ref:`Timeline`.
-
-.. _newClockTimer:
-
-newClockTimer
-^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newClockTimer :: Clock -> Timer
-
-Create a new :ref:`Timer` that uses the provided :ref:`Clock` as a source of the current :ref:`Time`.
-
-.. _newTimeline:
-
-newTimeline
-^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newTimeline :: () -> Timeline
-
-Create an empty :ref:`Timeline`
-
-.. _newPlatformClock:
-
-newPlatformClock
+Scheduling Tasks
 ^^^^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newPlatformClock :: () -> Clock
-
-Create a new :ref:`Clock` by autodetecting the best platform-specific source of :ref:`Time`.  On modern browsers, uses `performance.now`, and on Node, `process.hrtime`.  If neither is available, falls back to `Date.now`.
-
-.. _newPerformanceClock:
-
-newPerformanceClock
-^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newPerformanceClock :: () -> Clock
-
-Create a new :ref:`Clock` using`performance.now`.
-
-.. _newHRTimeClock:
-
-newHRTimeClock
-^^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newHRTimeClock :: () -> Clock
-
-Create a new :ref:`Clock` using`process.hrtime`.
-
-.. _newDateClock:
-
-newDateClock
-^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  newDateClock :: () -> Clock
-
-Create a new :ref:`Clock` using`Date.now`. Note that a Clock using `Date.now` is not guaranteed to be monotonic, and is subject to system clock changes, e.g. NTP can change your system clock!
-
-.. _clockRelativeTo
-
-clockRelativeTo
-^^^^^^^^^^^^^^^
-
-.. code-block:: haskell
-
-  clockRelativeTo :: Clock -> Clock
-
-Create a new :ref:`Clock` whose origin is at the *current time* (at the instant of calling ``clockRelativeTime``) of the provided Clock.
-
-.. _Scheduler-now:
-
-now
-^^^
-
-.. code-block:: haskell
-
-  now :: Scheduler ~> () -> Time
-
-Get the scheduler's current time.
 
 .. _Scheduler-asap:
 
 asap
-^^^^
+````
 
 .. code-block:: haskell
 
@@ -1267,7 +1162,7 @@ Schedule a Task to execute as soon as possible, but still asynchronously.
 .. _Scheduler-delay:
 
 delay
-^^^^^
+`````
 
 .. code-block:: haskell
 
@@ -1278,7 +1173,7 @@ Schedule a Task to execute after a specified millisecond Delay.
 .. _Scheduler-periodic:
 
 periodic
-^^^^^^^^
+````````
 
 .. code-block:: haskell
 
@@ -1286,10 +1181,77 @@ periodic
 
 Schedule a Task to execute periodically with the specified Period.
 
+.. _Canceling Tasks:
+
+Canceling Tasks
+^^^^^^^^^^^^^^^
+
+.. _Scheduler-cancelTask:
+
+cancelTask
+``````````
+
+.. code-block:: haskell
+
+  cancelTask :: ScheduledTask -> void
+
+Cancel all future scheduled executions of a ScheduledTask.
+
+.. _Scheduler-cancelAllTasks:
+
+cancelAllTasks
+``````````````
+
+.. code-block:: haskell
+
+  cancelAllTasks :: (ScheduledTask -> boolean) -> Scheduler -> void
+
+Cancel all future scheduled executions of all ScheduledTasks for which the provided predicate is true.
+
+Current Time
+^^^^^^^^^^^^
+
+.. _Scheduler-now:
+
+now
+```
+
+.. code-block:: haskell
+
+  now :: Scheduler ~> () -> Time
+
+Get the scheduler's current time.
+
+Creating a Scheduler
+^^^^^^^^^^^^^^^^^^^^
+
+.. _newScheduler:
+
+newScheduler
+````````````
+
+.. code-block:: haskell
+
+  newScheduler :: Timer -> Timeline -> Scheduler
+
+Create a new scheduler that uses the provided :ref:`Timer` and :ref:`Timeline` for scheduling tasks.
+
+.. _newDefaultScheduler:
+
+newDefaultScheduler
+```````````````````
+
+.. code-block:: haskell
+
+  newDefaultScheduler :: () -> Scheduler
+
+Create a new Scheduler that uses a default platform-specific :ref:`Timer` and new, empty :ref:`Timeline`.
+
+
 .. _Scheduler-relative:
 
 schedulerRelativeTo
-^^^^^^^^^^^^^^^^^^^
+```````````````````
 
 .. code-block:: haskell
 
@@ -1310,24 +1272,82 @@ When implementing higher-order stream combinators, this function can be used to 
   scheduler.now() //> 3929
   relativeScheduler.now() //> 2292
 
-.. _Scheduler-cancelTask:
+Timer, Timeline, and Clock
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-cancelTask
-^^^^^^^^^^
+.. _newClockTimer:
 
-.. code-block:: haskell
-
-  cancelTask :: ScheduledTask -> void
-
-Cancel all future scheduled executions of a ScheduledTask.
-
-.. _Scheduler-cancelAllTasks:
-
-cancelAllTasks
-^^^^^^^^^^^^^^
+newClockTimer
+`````````````
 
 .. code-block:: haskell
 
-  cancelAllTasks :: (ScheduledTask -> boolean) -> Scheduler -> void
+  newClockTimer :: Clock -> Timer
 
-Cancel all future scheduled executions of all ScheduledTasks for which the provided predicate is true.
+Create a new :ref:`Timer` that uses the provided :ref:`Clock` as a source of the current :ref:`Time`.
+
+.. _newTimeline:
+
+newTimeline
+```````````
+
+.. code-block:: haskell
+
+  newTimeline :: () -> Timeline
+
+Create an empty :ref:`Timeline`
+
+.. _newPlatformClock:
+
+newPlatformClock
+````````````````
+
+.. code-block:: haskell
+
+  newPlatformClock :: () -> Clock
+
+Create a new :ref:`Clock` by autodetecting the best platform-specific source of :ref:`Time`.  On modern browsers, uses `performance.now`, and on Node, `process.hrtime`.  If neither is available, falls back to `Date.now`.
+
+.. _newPerformanceClock:
+
+newPerformanceClock
+```````````````````
+
+.. code-block:: haskell
+
+  newPerformanceClock :: () -> Clock
+
+Create a new :ref:`Clock` using`performance.now`.
+
+.. _newHRTimeClock:
+
+newHRTimeClock
+``````````````
+
+.. code-block:: haskell
+
+  newHRTimeClock :: () -> Clock
+
+Create a new :ref:`Clock` using`process.hrtime`.
+
+.. _newDateClock:
+
+newDateClock
+````````````
+
+.. code-block:: haskell
+
+  newDateClock :: () -> Clock
+
+Create a new :ref:`Clock` using`Date.now`. Note that a Clock using `Date.now` is not guaranteed to be monotonic, and is subject to system clock changes, e.g. NTP can change your system clock!
+
+.. _clockRelativeTo:
+
+clockRelativeTo
+```````````````
+
+.. code-block:: haskell
+
+  clockRelativeTo :: Clock -> Clock
+
+Create a new :ref:`Clock` whose origin is at the *current time* (at the instant of calling ``clockRelativeTime``) of the provided Clock.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1351,3 +1351,86 @@ clockRelativeTo
   clockRelativeTo :: Clock -> Clock
 
 Create a new :ref:`Clock` whose origin is at the *current time* (at the instant of calling ``clockRelativeTime``) of the provided Clock.
+
+.. _@most/disposable:
+
+@most/disposable
+----------------
+
+.. _Creating Disposables:
+
+Creating Disposables
+^^^^^^^^^^^^^^^^^^^^
+
+.. _disposeNone:
+
+disposeNone
+```````````
+
+.. code-block:: haskell
+
+  disposeNone :: () -> Disposable
+
+Create a no-op :ref:`Disposable`.
+
+.. _ disposeWith:
+
+disposeWith
+```````````
+
+.. code-block:: haskell
+
+  disposeWith :: (a -> void) -> a -> Disposable
+
+Create a :ref:`Disposable` which, when disposed will call the provided function, passing the provided value.
+
+.. _disposeOnce:
+
+disposeOnce
+```````````
+
+.. code-block:: haskell
+
+  disposeOnce :: Disposable -> Disposable
+
+Wrap a :ref:`Disposable` so the underlying Disposable will only be disposed once, even if the returned Disposable is disposed multiple times.
+
+.. _disposeBoth:
+
+disposeBoth
+```````````
+
+.. code-block:: haskell
+
+  disposeBoth :: Disposable -> Disposable -> Disposable
+
+Combine two :ref:`Disposable`s into a single Disposable which will dispose both.
+
+.. _disposeAll:
+
+disposeAll
+``````````
+
+.. code-block:: haskell
+
+  disposeAll :: [Disposable] -> Disposable
+
+Combine an array of :ref:`Disposable`s into a single Disposable which will dispose all the Disposables in the array.
+
+.. _Disposing Disposables:
+
+Disposing Disposables
+^^^^^^^^^^^^^^^^^^^^^
+
+.. _tryDispose:
+
+tryDispose
+``````````
+
+.. code-block:: haskell
+
+  tryDispose :: Time -> Disposable -> Sink * -> void
+
+Attempt to dispose the provided :ref:`Disposable`.  If the Disposable throws an exception, catch and propagate it to the provided :ref:`Sink` with the provided :ref:`Time`.
+
+Note: Only an exception thrown by the Disposable will be caught.  If the act of propagating an error to the Sink throws, that exception *will not* be caught.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -14,3 +14,24 @@ Event Streams
 An *event stream* is a time-ordered series of events.  For example, all the mouse clicks in a document can be represented as an event stream.
 
 Conceptually, you can think of an event stream as an array of (time, value) pairs.  However, whereas an array is ordered by index, an event stream is ordered by its events' occurrence times.  You can't observe the second mouse click until after you've observed the first one.
+
+Source and sink chains
+----------------------
+
+Applying combinators to a stream composes a *source chain* that defines the behavior of the stream.  When an observer begins observing a stream, a :ref:`run <Stream>` message is sent "backwards" through the chain, to the ultimate producer--the one that will produce events in the first place.
+
+As it travels, that message composes a *:ref:`Sink` chain* analogous to the source chain.  When the messages reaches the producer, it begins producing events.  With the exception of a few combinators (such as :ref:`delay`), events propagate *synchronously* "forward" through the sink chain.
+
+**Note**: a producer must not *begin* producing events synchronously.  It must schedule the *start* of its production, using the :ref:`Scheduler` passed to its :ref:`run <Stream>` method.  However, once it does begin, it may then produce events synchronously.
+
+Event propagation
+-----------------
+
+Each event propagation is synchronous by default.  One sink calls the :ref:`event <Stream>` method of the next, forming a synchronous call stack.
+
+Some combinators, like :ref:`delay`, introduce asynchrony into the sink chain.
+
+Error propagation
+-----------------
+
+If an exception is thrown during event propagation, it will stop the propagation and travel "backwards" through the sink chain, by unwinding the call stack.  If that exception is not caught, it will reach the producer, and finally, the scheduler.  The scheduler will catch it and send the error "forward" again synchronously, using the `error` channel of the sink chain.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -27,7 +27,7 @@ As it travels, that message composes a *:ref:`Sink` chain* analogous to the sour
 Event propagation
 -----------------
 
-Each event propagation is synchronous by default.  One sink calls the :ref:`event <Stream>` method of the next, forming a synchronous call stack.
+Each event propagation is synchronous by default.  One sink calls the :ref:`event <Sink>` method of the next, forming a synchronous call stack.
 
 Some combinators, like :ref:`delay`, introduce asynchrony into the sink chain.
 

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -1,9 +1,5 @@
 // @flow
-import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types'
-
-export type Clock = {
-  now (): Time
-}
+import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Clock, Delay, Period, Offset } from '@most/types'
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler
 declare export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -1,8 +1,4 @@
-import { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Delay, Period, Offset } from '@most/types';
-
-export type Clock = {
-  now: () => Time
-};
+import { Scheduler, Task, ScheduledTask, Timeline, Timer, Clock, Delay, Period, Offset } from '@most/types';
 
 export function newScheduler (timer: Timer, timeline: Timeline): Scheduler;
 export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -3,6 +3,11 @@
 // in use
 export type Time = number;
 
+// A Clock represents a source of the current time
+export type Clock = {
+  now (): Time;
+}
+
 export interface Stream<A> {
   run (sink: Sink<A>, scheduler: Scheduler): Disposable;
 }

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -5,6 +5,11 @@
 // in use
 export type Time = number
 
+// A Clock represents a source of the current time
+export type Clock = {
+  now (): Time
+}
+
 export type Stream<A> = {
   run (Sink<A>, Scheduler): Disposable
 }


### PR DESCRIPTION
The goal of this PR is to add documentation for:

1. all packages except `@most/prelude` (I'm imagining a separate PR for that)
2. the core types
3. as much of the info in the [Architecture wiki](https://github.com/cujojs/most/wiki/Architecture) that makes sense in the current structure
    * I'd rather not hold up this PR to try to integrate all of the Architecture info.  We can discuss and do that in another PR.
