### PR TITLE
fix(debounce): ensure debounce disposes source

### DIFF
--- a/packages/core/src/combinator/limit.js
+++ b/packages/core/src/combinator/limit.js
@@ -1,9 +1,6 @@
-/** @license MIT License (c) copyright 2010-2016 original author or authors */
-/** @author Brian Cavalier */
-/** @author John Hann */
+/** @license MIT License (c) copyright 2010-2017 original author or authors */
 
 import Pipe from '../sink/Pipe'
-import { disposeBoth } from '@most/disposable'
 import { propagateEventTask } from '../scheduler/PropagateTask'
 import Map from '../fusion/Map'
 
@@ -78,8 +75,7 @@ class DebounceSink {
     this.value = void 0
     this.timer = null
 
-    const sourceDisposable = source.run(this, scheduler)
-    this.disposable = disposeBoth(this, sourceDisposable)
+    this.disposable = source.run(this, scheduler)
   }
 
   event (t, x) {
@@ -103,6 +99,7 @@ class DebounceSink {
 
   dispose () {
     this._clearTimer()
+    this.disposable.dispose()
   }
 
   _clearTimer () {

--- a/packages/core/test/limit-test.js
+++ b/packages/core/test/limit-test.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha'
 import { eq, is, assert } from '@briancavalier/assert'
+import { spy } from 'sinon'
 
 import { debounce, throttle } from '../src/combinator/limit'
 import { zip } from '../src/combinator/zip'
@@ -11,6 +12,7 @@ import { default as Map } from '../src/fusion/Map'
 
 import { atTimes, collectEventsFor, makeEventsFromArray, makeEvents } from './helper/testEnv'
 import { assertSame } from './helper/stream-helper'
+import FakeDisposeSource from './helper/FakeDisposeStream'
 
 const sentinel = { value: 'sentinel' }
 
@@ -77,6 +79,15 @@ describe('debounce', function () {
         { time: 4, value: 1 },
         { time: 7, value: 2 }
       ]))
+  })
+
+  it('should dispose source', () => {
+    const dispose = spy()
+    const s = new FakeDisposeSource(dispose, now(sentinel))
+    const debounced = debounce(1, s)
+
+    return collectEventsFor(1, debounced).then(() =>
+      assert(dispose.calledOnce))
   })
 })
 

--- a/packages/core/test/limit-test.js
+++ b/packages/core/test/limit-test.js
@@ -5,7 +5,6 @@ import { spy } from 'sinon'
 import { debounce, throttle } from '../src/combinator/limit'
 import { zip } from '../src/combinator/zip'
 import { map } from '../src/combinator/transform'
-import { take } from '../src/combinator/slice'
 import { empty } from '../src/source/empty'
 import { now } from '../src/source/now'
 import { default as Map } from '../src/fusion/Map'
@@ -130,7 +129,7 @@ describe('throttle', function () {
 
   it('should be identity when period === 0 and all items are simultaneous', function () {
     const a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    const s = take(10, makeEventsFromArray(0, a))
+    const s = makeEventsFromArray(0, a)
     return assertSame(s, throttle(0, s))
   })
 


### PR DESCRIPTION
Ported from https://github.com/cujojs/most/pull/472

It looks like there was also a bug in the DebounceSink constructor.  It wasn't correct to use disposeBoth, since the DebounceSink instance is already the disposable that is being returned from run().