### PR TITLE
fix(types): propagateTask; decouple value type from sink type

### DIFF
--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -197,15 +197,15 @@ declare export class MulticastSource <A> {
   dispose(): void;
 }
 
-export type PropagateTask<A> = Task & {
+export type PropagateTask<A, B> = Task & {
   value: A,
-  sink: Sink<A>,
+  sink: Sink<B>,
   active: boolean
 }
 
-export type PropagateTaskRun<A> = (time: Time, value: A, sink: Sink<A>) => any
+export type PropagateTaskRun<A, B> = (time: Time, value: A, sink: Sink<B>) => any
 
-declare export function propagateTask<A> (run: PropagateTaskRun<A>, value: A, sink: Sink<A>): PropagateTask<A>
-declare export function propagateEventTask<A> (value: A, sink: Sink<A>): PropagateTask<A>
-declare export function propagateErrorTask<E: Error> (e: E, sink: Sink<any>): PropagateTask<any>
-declare export function propagateEndTask (sink: Sink<any>): PropagateTask<void>
+declare export function propagateTask<A, B> (run: PropagateTaskRun<A, B>, value: A, sink: Sink<B>): PropagateTask<A, B>
+declare export function propagateEventTask<A> (value: A, sink: Sink<A>): PropagateTask<A, A>
+declare export function propagateErrorTask<E: Error> (e: E, sink: Sink<any>): PropagateTask<any, any>
+declare export function propagateEndTask (sink: Sink<any>): PropagateTask<void, void>

--- a/packages/core/type-definitions/PropagateTask.d.ts
+++ b/packages/core/type-definitions/PropagateTask.d.ts
@@ -1,9 +1,9 @@
 import { Sink, Task } from '@most/types';
 
-export function propagateTask<T>(run: PropagateTaskRun<T>, value: T, sink: Sink<T>): PropagateTask<T>;
-export function propagateTask<T>(run: PropagateTaskRun<T>, value: T): (sink: Sink<T>) => PropagateTask<T>;
-export function propagateTask<T>(run: PropagateTaskRun<T>): (value: T, sink: Sink<T>) => PropagateTask<T>;
-export function propagateTask<T>(run: PropagateTaskRun<T>): (value: T) => (sink: Sink<T>) => PropagateTask<T>;
+export function propagateTask<A, B = A>(run: PropagateTaskRun<A, B>, value: A, sink: Sink<B>): PropagateTask<A, B>;
+export function propagateTask<A, B = A>(run: PropagateTaskRun<A, B>, value: A): (sink: Sink<B>) => PropagateTask<A, B>;
+export function propagateTask<A, B = A>(run: PropagateTaskRun<A, B>): (value: A, sink: Sink<B>) => PropagateTask<A, B>;
+export function propagateTask<A, B = A>(run: PropagateTaskRun<A, B>): (value: A) => (sink: Sink<B>) => PropagateTask<A, B>;
 
 export function propagateEventTask<T>(value: T, sink: Sink<T>): PropagateTask<T>;
 export function propagateEventTask<T>(value: T): (sink: Sink<T>) => PropagateTask<T>;
@@ -13,11 +13,11 @@ export function propagateEndTask<T>(sink: Sink<T>): PropagateTask<void>;
 export function propagateErrorTask(error: Error, sink: Sink<any>): PropagateTask<any>;
 export function propagateErrorTask(error: Error): (sink: Sink<any>) => PropagateTask<any>;
 
-export type PropagateTaskRun<A> =
-  (time: number, value: A, sink: Sink<A>) => any
+export type PropagateTaskRun<A, B = A> =
+  (time: number, value: A, sink: Sink<B>) => any
 
-export interface PropagateTask<A> extends Task {
+export interface PropagateTask<A, B = A> extends Task {
   value: A;
-  sink: Sink<A>;
+  sink: Sink<B>;
   active: boolean;
 }


### PR DESCRIPTION
Without this change, propagateTask can't be used to pass a wrapper object as the value, with the internal values then unwrapped by the task runner for delivery to the sink.