### PR TITLE
chore(build): stop bundling deps into builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,6 @@
     "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
     "sinon": "^1.17.7",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -5,6 +5,11 @@ export default {
   plugins: [
     buble()
   ],
+  external: [
+    '@most/scheduler',
+    '@most/disposable',
+    '@most/prelude'
+  ],
   targets: [
     {
       dest: 'dist/mostCore.js',

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,20 +1,21 @@
 import buble from 'rollup-plugin-buble'
-import nodeResolve from 'rollup-plugin-node-resolve'
 
 export default {
   entry: 'src/index.js',
   plugins: [
-    buble(),
-    nodeResolve({
-      jsnext: true
-    })
+    buble()
   ],
   targets: [
     {
       dest: 'dist/mostCore.js',
       format: 'umd',
       moduleName: 'mostCore',
-      sourceMap: true
+      sourceMap: true,
+      globals: {
+        '@most/scheduler': 'mostScheduler',
+        '@most/disposable': 'mostDisposable',
+        '@most/prelude': 'mostPrelude'
+      }
     },
     {
       dest: 'dist/mostCore.es.js',

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -47,7 +47,6 @@
     "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
     "sinon": "^1.17.7",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",

--- a/packages/disposable/rollup.config.js
+++ b/packages/disposable/rollup.config.js
@@ -1,20 +1,19 @@
 import buble from 'rollup-plugin-buble'
-import nodeResolve from 'rollup-plugin-node-resolve'
 
 export default {
   entry: 'src/index.js',
   plugins: [
-    buble(),
-    nodeResolve({
-      jsnext: true
-    })
+    buble()
   ],
   targets: [
     {
       dest: 'dist/index.js',
       format: 'umd',
       moduleName: 'mostDisposable',
-      sourceMap: true
+      sourceMap: true,
+      globals: {
+        '@most/prelude': 'mostPrelude'
+      }
     },
     {
       dest: 'dist/index.es.js',

--- a/packages/disposable/rollup.config.js
+++ b/packages/disposable/rollup.config.js
@@ -5,6 +5,9 @@ export default {
   plugins: [
     buble()
   ],
+  external: [
+    '@most/prelude'
+  ],
   targets: [
     {
       dest: 'dist/index.js',

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -48,7 +48,6 @@
     "nyc": "^11.0.2",
     "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
     "sinon": "^1.17.7",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",

--- a/packages/scheduler/rollup.config.js
+++ b/packages/scheduler/rollup.config.js
@@ -1,20 +1,19 @@
 import buble from 'rollup-plugin-buble'
-import nodeResolve from 'rollup-plugin-node-resolve'
 
 export default {
   entry: 'src/index.js',
   plugins: [
-    buble(),
-    nodeResolve({
-      jsnext: true
-    })
+    buble()
   ],
   targets: [
     {
       dest: 'dist/index.js',
       format: 'umd',
       moduleName: 'mostCore',
-      sourceMap: true
+      sourceMap: true,
+      globals: {
+        '@most/prelude': 'mostPrelude'
+      }
     },
     {
       dest: 'dist/index.es.js',

--- a/packages/scheduler/rollup.config.js
+++ b/packages/scheduler/rollup.config.js
@@ -5,6 +5,9 @@ export default {
   plugins: [
     buble()
   ],
+  external: [
+    '@most/prelude'
+  ],
   targets: [
     {
       dest: 'dist/index.js',


### PR DESCRIPTION
In the same vein as https://github.com/mostjs/hold/pull/22, this stops bundling deps into each package.  Without this change, for example, we end up with a copy of `@most/prelude` functions in `@most/core`, `@most/disposable`, and `@most/scheduler`.  An application that uses `@most/core` would ultimately end up with 3 copies of some `@most/prelude` functions!  I verified this using the example in #139.  In that tiny example, it reduced the (unminified and non-gzipped) size by 10k.  Perhaps more importantly, it ended up with no duplicate functions.