### PR TITLE
docs(concepts): Add finite, infinite, failed stream info, periodic docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -268,7 +268,7 @@ periodic
 
 Create an infinite :ref:`Stream` containing events that occur at a specified period. ::
 
-  periodic(3): .--.--.--.-->
+  periodic(3): x--x--x--x-->
 
 The first event occurs at time 0, and the event values are ``undefined``.
 
@@ -281,7 +281,7 @@ throwError
 
   throwError :: Error -> Stream void
 
-Create a :ref:`Stream` that fails at time 0 with the provided ``Error``.  This can be useful for functions that need to return a :ref:`Stream` and also need to propagate an error. ::
+Create a :ref:`Stream` that fails with the provided ``Error`` at time 0.  This can be useful for functions that need to return a :ref:`Stream` and also need to propagate an error. ::
 
   throwError(X): X
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -32,7 +32,7 @@ An event stream may be finite.  A finite event stream will produce an *end signa
 Failed Event Streams
 ^^^^^^^^^^^^^^^^^^^^
 
-An event stream may fail.  For example, when an event stream represents a resource, such as a websocket, and the resource fails or closes unexpectedly, the event stream *cannot* produce more events.  When an event stream fails, it will produce a *error signal* to indicate that it cannot produce more events.  The error signal includes a *reason* (an ``Error`` object) describing the failure.
+An event stream may fail.  For example, when an event stream represents a resource, such as a WebSocket, and the resource fails or closes unexpectedly, the event stream *cannot* produce more events.  When an event stream fails, it will produce an *error signal* to indicate that it cannot produce more events.  The error signal includes a *reason* (an ``Error`` object) describing the failure.
 
 A failed event stream will attempt to free any underlying resources.
 
@@ -43,9 +43,9 @@ The :ref:`recoverWith` operation allows you to handle an event stream failure.
 Stream Failure vs. Application Errors
 `````````````````````````````````````
 
-Stream failures are different from *application errors*.  A stream failure indicates that an event stream *cannot* produce more events.  Application errors may or may not indicate an event stream failure.  For example, an event stream representing messages arriving on a websocket *fails* if the websocket is disconnected unexpectedly due to a wifi drop.  In contrast, an application error may occur in application logic that receives a websocket message and can't process because the message application state has changed.
+Stream failures are different from *application errors*.  A stream failure indicates that an event stream *cannot* produce more events.  Application errors may or may not indicate an event stream failure.  For example, an event stream representing messages arriving on a WebSocket *fails* if the WebSocket is disconnected unexpectedly due to a wifi drop.  In contrast, an application error may occur in application logic that receives a WebSocket message and can't process because the message application state has changed.
 
-Application error handling is outside the scope of these docs, as it is applications-specific.  However, there are some general strategies for dealing with application errors with event streams:
+Application error handling is outside the scope of these docs, as it is application-specific.  However, there are some general strategies for dealing with application errors with event streams:
 
 * Use try/catch, `Promise catch() <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch>`_ to handle the application error and transform it into:
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -15,12 +15,31 @@ An *event stream* is a time-ordered series of events.  For example, all the mous
 
 Conceptually, you can think of an event stream as an array of (time, value) pairs.  However, whereas an array is ordered by index, an event stream is ordered by its events' occurrence times.  You can't observe the second mouse click until after you've observed the first one.
 
+Event streams may be *infinite*, *finite*, or may *fail*.
+
+Infinite Event Streams
+``````````````````````
+
+An event stream may be infinite.  For example, :ref:`periodic` creates an infinite stream of events that occur at a regular period.  Limiting operations, such as :ref:`take` or :ref:`until`, are helpful in turning an infinite event stream into a finite one.
+
+Finite Event Streams
+````````````````````
+
+An event stream may be finite.  A finite event stream will produce an *end signal* to indicate that it will never produce another event.
+
+Failed Event Streams
+````````````````````
+
+An event stream may fail.  For example, when an event stream represents a resource, such as a websocket, and the resource fails or closes unexpectedly, the event stream *cannot* produce more events.  When an event stream fails, it will produce a *error signal* to indicate that it cannot produce more events.  The error signal includes a *reason* (an ``Error`` object) describing the failure.
+
+The :ref:`recoverWith` operation allows you to handle an event stream failure.
+
 Source and sink chains
 ----------------------
 
 Applying combinators to a stream composes a *source chain* that defines the behavior of the stream.  When an observer begins observing a stream, a :ref:`run <Stream>` message is sent "backwards" through the chain, to the ultimate producer--the one that will produce events in the first place.
 
-As it travels, that message composes a *:ref:`Sink` chain* analogous to the source chain.  When the messages reaches the producer, it begins producing events.  With the exception of a few combinators (such as :ref:`delay`), events propagate *synchronously* "forward" through the sink chain.
+As it travels, that message composes a :ref:`Sink` chain analogous to the source chain.  When the messages reaches the producer, it begins producing events.  With the exception of a few combinators (such as :ref:`delay`), events propagate *synchronously* "forward" through the sink chain.
 
 **Note**: a producer must not *begin* producing events synchronously.  It must schedule the *start* of its production, using the :ref:`Scheduler` passed to its :ref:`run <Stream>` method.  However, once it does begin, it may then produce events synchronously.
 


### PR DESCRIPTION
Add some info on finite and infinite streams, and attempt to clarify stream failures vs. application errors.  Docs for `periodic` were missing, so I added them along the way.

I also fixed some sphinx errors.  It seems to get confused when you have a `:ref:` or inline code/preformatted span that *isn't immediately surrounded by spaces*.  For example, these are problematic:

```rst
Some :ref:`Stream`s blah blah

Some ``Stream``s blah blah
```

I don't have a good solution to the second one.  The first one can be solved by using the explicit text+reference syntax:

```rst
Some :ref:`Streams <Stream>`
```