### PR TITLE
feat(slice): improve empty slice detection

### DIFF
--- a/packages/core/src/combinator/slice.js
+++ b/packages/core/src/combinator/slice.js
@@ -1,7 +1,7 @@
 /** @license MIT License (c) copyright 2010 original author or authors */
 
 import Pipe from '../sink/Pipe'
-import { empty } from '../source/empty'
+import { empty, isCanonicalEmpty } from '../source/empty'
 import Map from '../fusion/Map'
 import SettableDisposable from '../disposable/SettableDisposable'
 
@@ -29,7 +29,7 @@ export const skip = (n, stream) =>
  * @returns {Stream} stream containing items where start <= index < end
  */
 export const slice = (start, end, stream) =>
-  end <= start || stream === empty()
+  end <= start || isCanonicalEmpty(stream)
     ? empty()
     : sliceSource(start, end, stream)
 

--- a/packages/core/src/combinator/slice.js
+++ b/packages/core/src/combinator/slice.js
@@ -1,6 +1,4 @@
-/** @license MIT License (c) copyright 2010-2016 original author or authors */
-/** @author Brian Cavalier */
-/** @author John Hann */
+/** @license MIT License (c) copyright 2010 original author or authors */
 
 import Pipe from '../sink/Pipe'
 import { empty } from '../source/empty'
@@ -31,7 +29,9 @@ export const skip = (n, stream) =>
  * @returns {Stream} stream containing items where start <= index < end
  */
 export const slice = (start, end, stream) =>
-  end <= start ? empty() : sliceSource(start, end, stream)
+  end <= start || stream === empty()
+    ? empty()
+    : sliceSource(start, end, stream)
 
 const sliceSource = (start, end, stream) =>
   stream instanceof Map ? commuteMapSlice(start, end, stream)
@@ -39,12 +39,12 @@ const sliceSource = (start, end, stream) =>
     : new Slice(start, end, stream)
 
 const commuteMapSlice = (start, end, mapStream) =>
-  Map.create(mapStream.f, sliceSource(start, end, mapStream.source))
+  Map.create(mapStream.f, slice(start, end, mapStream.source))
 
 function fuseSlice (start, end, sliceStream) {
   const fusedStart = start + sliceStream.min
   const fusedEnd = Math.min(end + sliceStream.min, sliceStream.max)
-  return new Slice(fusedStart, fusedEnd, sliceStream.source)
+  return slice(fusedStart, fusedEnd, sliceStream.source)
 }
 
 class Slice {

--- a/packages/core/src/source/empty.js
+++ b/packages/core/src/source/empty.js
@@ -5,6 +5,9 @@ import { asap } from '@most/scheduler'
 
 export const empty = () => EMPTY
 
+export const isCanonicalEmpty = stream =>
+  stream === EMPTY
+
 class Empty {
   run (sink, scheduler) {
     return asap(propagateEndTask(sink), scheduler)

--- a/packages/core/test/slice-test.js
+++ b/packages/core/test/slice-test.js
@@ -3,6 +3,7 @@ import { eq, is, assert } from '@briancavalier/assert'
 
 import { slice, take, skip, takeWhile, skipWhile, skipAfter } from '../src/combinator/slice'
 import { map } from '../src/combinator/transform'
+import { now } from '../src/source/now'
 import { empty } from '../src/source/empty'
 import { default as Map } from '../src/fusion/Map'
 
@@ -11,14 +12,27 @@ import { assertSame } from './helper/stream-helper'
 
 describe('slice', function () {
   describe('fusion', function () {
+    it('should return empty given empty', () => {
+      is(empty(), slice(0, 1, empty()))
+    })
+
+    it('should return empty given zero-length slice', () => {
+      const i = Math.floor(Math.random() * 1000)
+      is(empty(), slice(i, i, now(i)))
+    })
+
+    it('should return empty when fusion leads to zero-length slice', () => {
+      is(empty(), slice(1, 2, slice(1, 2, now(''))))
+    })
+
     it('should narrow when second slice is smaller', function () {
-      const s = slice(1, 5, slice(1, 10, makeEvents(1, 1)))
+      const s = slice(1, 5, slice(1, 10, now('')))
       eq(2, s.min)
       eq(6, s.max)
     })
 
     it('should narrow when second slice is larger', function () {
-      const s = slice(1, 10, slice(1, 5, makeEvents(1, 1)))
+      const s = slice(1, 10, slice(1, 5, now('')))
       eq(2, s.min)
       eq(5, s.max)
     })

--- a/packages/core/test/source/empty-test.js
+++ b/packages/core/test/source/empty-test.js
@@ -1,13 +1,25 @@
 // @flow
 import { describe, it } from 'mocha'
-import { eq } from '@briancavalier/assert'
+import { eq, assert } from '@briancavalier/assert'
 
-import { empty } from '../../src/source/empty'
+import { empty, isCanonicalEmpty } from '../../src/source/empty'
 
-import { collectEventsFor } from '../helper/testEnv'
+import { collectEventsFor, makeEvents } from '../helper/testEnv'
 
 describe('empty', () => {
-  it('should yield no items before end', () => {
-    return collectEventsFor(1, empty()).then(eq([]))
+  describe('isEmpty', () => {
+    it('should return true given empty()', () => {
+      assert(isCanonicalEmpty(empty()))
+    })
+
+    it('should return false given non-empty()', () => {
+      assert(!isCanonicalEmpty(makeEvents(1, 0)))
+    })
+  })
+
+  describe('empty', () => {
+    it('should yield no items before end', () => {
+      return collectEventsFor(1, empty()).then(eq([]))
+    })
   })
 })


### PR DESCRIPTION
See #150, specifically the "Make slice fusion smarter about empty()" section.

This PR improves detection of empty slices.  If slice detects that it has reached the point where it could only return an empty stream, it will return canonical `empty()`.  Specifically, it now detects these cases _recursively_:

* when it computes end <= start
* when it encounters canonical `empty()`
