### PR TITLE
Try lerna-changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,477 @@
+
+## @most/core@1.0.0-beta.0 (2017-10-25)
+
+#### :rocket: Enhancement
+* [#162](https://github.com/mostjs/core/pull/162) docs(index): Remove Note, add examples link. ([@briancavalier](https://github.com/briancavalier))
+* [#161](https://github.com/mostjs/core/pull/161) Reword Source and sink chains. ([@Frikki](https://github.com/Frikki))
+* [#157](https://github.com/mostjs/core/pull/157) docs(FAQ): start FAQ. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+
+
+## @most/disposable@1.0.0-beta.0 (2017-10-25)
+
+#### :rocket: Enhancement
+* [#162](https://github.com/mostjs/core/pull/162) docs(index): Remove Note, add examples link. ([@briancavalier](https://github.com/briancavalier))
+* [#161](https://github.com/mostjs/core/pull/161) Reword Source and sink chains. ([@Frikki](https://github.com/Frikki))
+* [#157](https://github.com/mostjs/core/pull/157) docs(FAQ): start FAQ. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+
+
+## @most/scheduler@1.0.0-beta.0 (2017-10-25)
+
+#### :rocket: Enhancement
+* [#162](https://github.com/mostjs/core/pull/162) docs(index): Remove Note, add examples link. ([@briancavalier](https://github.com/briancavalier))
+* [#161](https://github.com/mostjs/core/pull/161) Reword Source and sink chains. ([@Frikki](https://github.com/Frikki))
+* [#157](https://github.com/mostjs/core/pull/157) docs(FAQ): start FAQ. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+
+
+## @most/types@1.0.0-beta.0 (2017-10-25)
+
+#### :rocket: Enhancement
+* [#162](https://github.com/mostjs/core/pull/162) docs(index): Remove Note, add examples link. ([@briancavalier](https://github.com/briancavalier))
+* [#161](https://github.com/mostjs/core/pull/161) Reword Source and sink chains. ([@Frikki](https://github.com/Frikki))
+* [#157](https://github.com/mostjs/core/pull/157) docs(FAQ): start FAQ. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+
+
+## @most/core@0.15.0 (2017-10-23)
+
+#### :rocket: Enhancement
+* Other
+  * [#153](https://github.com/mostjs/core/pull/153) docs(concepts): Fix grammar in application errors section. ([@briancavalier](https://github.com/briancavalier))
+  * [#144](https://github.com/mostjs/core/pull/144) docs(concepts): Add finite, infinite, failed stream info, periodic docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#146](https://github.com/mostjs/core/pull/146) chore(examples): update example deps. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#149](https://github.com/mostjs/core/pull/149) fix: simplify ZipArrayValuesSink logic. ([@TylorS](https://github.com/TylorS))
+  * [#151](https://github.com/mostjs/core/pull/151) feat(slice): improve empty slice detection. ([@briancavalier](https://github.com/briancavalier))
+  * [#148](https://github.com/mostjs/core/pull/148) feat(snapshot): Rename sample -> snapshot, add new sample. ([@briancavalier](https://github.com/briancavalier))
+
+#### :bug: Bug Fix
+* `core`
+  * [#154](https://github.com/mostjs/core/pull/154) fix(types): Fix zipItems/withItems types. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Tylor Steinberger ([TylorS](https://github.com/TylorS))
+
+
+## @most/core@0.14.0 (2017-10-06)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `scheduler`
+  * [#141](https://github.com/mostjs/core/pull/141) chore(build): stop bundling deps into builds. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#139](https://github.com/mostjs/core/pull/139) feat(examples): Add simple example counter. ([@briancavalier](https://github.com/briancavalier))
+  * [#137](https://github.com/mostjs/core/pull/137) chore(DOCS): add multicast. ([@davidchase](https://github.com/davidchase))
+  * [#128](https://github.com/mostjs/core/pull/128) Correct grammar, typos, spelling, and formatting. ([@Frikki](https://github.com/Frikki))
+  * [#127](https://github.com/mostjs/core/pull/127) docs(README): Remove example. ([@briancavalier](https://github.com/briancavalier))
+  * [#126](https://github.com/mostjs/core/pull/126) docs(README): Add links. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#120](https://github.com/mostjs/core/pull/120) feat(core): Add runStream as function from of stream.run. ([@briancavalier](https://github.com/briancavalier))
+  * [#130](https://github.com/mostjs/core/pull/130) chore(core): remove defaultScheduler. ([@davidchase](https://github.com/davidchase))
+  * [#129](https://github.com/mostjs/core/pull/129) chore(core): update some files to es6 classes. ([@davidchase](https://github.com/davidchase))
+
+#### Committers: 4
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+- Nathan Ridley ([axefrog](https://github.com/axefrog))
+
+
+## @most/disposable@0.13.1 (2017-10-06)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `scheduler`
+  * [#141](https://github.com/mostjs/core/pull/141) chore(build): stop bundling deps into builds. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#139](https://github.com/mostjs/core/pull/139) feat(examples): Add simple example counter. ([@briancavalier](https://github.com/briancavalier))
+  * [#137](https://github.com/mostjs/core/pull/137) chore(DOCS): add multicast. ([@davidchase](https://github.com/davidchase))
+  * [#128](https://github.com/mostjs/core/pull/128) Correct grammar, typos, spelling, and formatting. ([@Frikki](https://github.com/Frikki))
+  * [#127](https://github.com/mostjs/core/pull/127) docs(README): Remove example. ([@briancavalier](https://github.com/briancavalier))
+  * [#126](https://github.com/mostjs/core/pull/126) docs(README): Add links. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#120](https://github.com/mostjs/core/pull/120) feat(core): Add runStream as function from of stream.run. ([@briancavalier](https://github.com/briancavalier))
+  * [#130](https://github.com/mostjs/core/pull/130) chore(core): remove defaultScheduler. ([@davidchase](https://github.com/davidchase))
+  * [#129](https://github.com/mostjs/core/pull/129) chore(core): update some files to es6 classes. ([@davidchase](https://github.com/davidchase))
+
+#### Committers: 4
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+- Nathan Ridley ([axefrog](https://github.com/axefrog))
+
+
+## @most/scheduler@0.13.1 (2017-10-06)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `scheduler`
+  * [#141](https://github.com/mostjs/core/pull/141) chore(build): stop bundling deps into builds. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#139](https://github.com/mostjs/core/pull/139) feat(examples): Add simple example counter. ([@briancavalier](https://github.com/briancavalier))
+  * [#137](https://github.com/mostjs/core/pull/137) chore(DOCS): add multicast. ([@davidchase](https://github.com/davidchase))
+  * [#128](https://github.com/mostjs/core/pull/128) Correct grammar, typos, spelling, and formatting. ([@Frikki](https://github.com/Frikki))
+  * [#127](https://github.com/mostjs/core/pull/127) docs(README): Remove example. ([@briancavalier](https://github.com/briancavalier))
+  * [#126](https://github.com/mostjs/core/pull/126) docs(README): Add links. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#120](https://github.com/mostjs/core/pull/120) feat(core): Add runStream as function from of stream.run. ([@briancavalier](https://github.com/briancavalier))
+  * [#130](https://github.com/mostjs/core/pull/130) chore(core): remove defaultScheduler. ([@davidchase](https://github.com/davidchase))
+  * [#129](https://github.com/mostjs/core/pull/129) chore(core): update some files to es6 classes. ([@davidchase](https://github.com/davidchase))
+
+#### Committers: 4
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+- Frederik Krautwald ([Frikki](https://github.com/Frikki))
+- Nathan Ridley ([axefrog](https://github.com/axefrog))
+
+
+## @most/core@0.13.0 (2017-09-04)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#122](https://github.com/mostjs/core/pull/122) chore(linting): only add standard for now. ([@davidchase](https://github.com/davidchase))
+* `disposable`
+  * [#118](https://github.com/mostjs/core/pull/118) feat(disposable): Add dispose function. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#119](https://github.com/mostjs/core/pull/119) chore(lerna): update lerna to latest. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`, `types`
+  * [#117](https://github.com/mostjs/core/pull/117) feat(scheduler): Add currentTime free function for reading scheduler time. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+
+
+## @most/disposable@0.13.0 (2017-09-04)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#122](https://github.com/mostjs/core/pull/122) chore(linting): only add standard for now. ([@davidchase](https://github.com/davidchase))
+* `disposable`
+  * [#118](https://github.com/mostjs/core/pull/118) feat(disposable): Add dispose function. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#119](https://github.com/mostjs/core/pull/119) chore(lerna): update lerna to latest. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`, `types`
+  * [#117](https://github.com/mostjs/core/pull/117) feat(scheduler): Add currentTime free function for reading scheduler time. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+
+
+## @most/prelude@1.6.4 (2017-09-04)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#122](https://github.com/mostjs/core/pull/122) chore(linting): only add standard for now. ([@davidchase](https://github.com/davidchase))
+* `disposable`
+  * [#118](https://github.com/mostjs/core/pull/118) feat(disposable): Add dispose function. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#119](https://github.com/mostjs/core/pull/119) chore(lerna): update lerna to latest. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`, `types`
+  * [#117](https://github.com/mostjs/core/pull/117) feat(scheduler): Add currentTime free function for reading scheduler time. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+
+
+## @most/scheduler@0.13.0 (2017-09-04)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#122](https://github.com/mostjs/core/pull/122) chore(linting): only add standard for now. ([@davidchase](https://github.com/davidchase))
+* `disposable`
+  * [#118](https://github.com/mostjs/core/pull/118) feat(disposable): Add dispose function. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#119](https://github.com/mostjs/core/pull/119) chore(lerna): update lerna to latest. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`, `types`
+  * [#117](https://github.com/mostjs/core/pull/117) feat(scheduler): Add currentTime free function for reading scheduler time. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+
+
+## @most/types@0.11.1 (2017-09-04)
+
+#### :rocket: Enhancement
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#122](https://github.com/mostjs/core/pull/122) chore(linting): only add standard for now. ([@davidchase](https://github.com/davidchase))
+* `disposable`
+  * [#118](https://github.com/mostjs/core/pull/118) feat(disposable): Add dispose function. ([@briancavalier](https://github.com/briancavalier))
+* Other
+  * [#119](https://github.com/mostjs/core/pull/119) chore(lerna): update lerna to latest. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`, `types`
+  * [#117](https://github.com/mostjs/core/pull/117) feat(scheduler): Add currentTime free function for reading scheduler time. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+
+
+## @most/core@0.12.1 (2017-08-28)
+
+#### :rocket: Enhancement
+* `core`
+  * [#115](https://github.com/mostjs/core/pull/115) fix(types): fix continueWith flow types. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Bogdan Chadkin ([TrySound](https://github.com/TrySound))
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/core@0.12.0 (2017-08-24)
+
+#### :rocket: Enhancement
+* Other
+  * [#112](https://github.com/mostjs/core/pull/112) chore(ci): stop testing on node 4, to avoid npm 2. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#106](https://github.com/mostjs/core/pull/106) docs(api): Expand API docs. ([@briancavalier](https://github.com/briancavalier))
+* `disposable`
+  * [#110](https://github.com/mostjs/core/pull/110) feat(disposable): curry API. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`
+  * [#109](https://github.com/mostjs/core/pull/109) chore(lerna): update lerna to 2.0.0. Ignore problematic files. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`, `types`
+  * [#108](https://github.com/mostjs/core/pull/108) feat(scheduler): Add scheduler functions. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/disposable@0.12.0 (2017-08-24)
+
+#### :rocket: Enhancement
+* Other
+  * [#112](https://github.com/mostjs/core/pull/112) chore(ci): stop testing on node 4, to avoid npm 2. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#106](https://github.com/mostjs/core/pull/106) docs(api): Expand API docs. ([@briancavalier](https://github.com/briancavalier))
+* `disposable`
+  * [#110](https://github.com/mostjs/core/pull/110) feat(disposable): curry API. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`
+  * [#109](https://github.com/mostjs/core/pull/109) chore(lerna): update lerna to 2.0.0. Ignore problematic files. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`, `types`
+  * [#108](https://github.com/mostjs/core/pull/108) feat(scheduler): Add scheduler functions. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/prelude@1.6.3 (2017-08-24)
+
+#### :rocket: Enhancement
+* Other
+  * [#112](https://github.com/mostjs/core/pull/112) chore(ci): stop testing on node 4, to avoid npm 2. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#106](https://github.com/mostjs/core/pull/106) docs(api): Expand API docs. ([@briancavalier](https://github.com/briancavalier))
+* `disposable`
+  * [#110](https://github.com/mostjs/core/pull/110) feat(disposable): curry API. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`
+  * [#109](https://github.com/mostjs/core/pull/109) chore(lerna): update lerna to 2.0.0. Ignore problematic files. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`, `types`
+  * [#108](https://github.com/mostjs/core/pull/108) feat(scheduler): Add scheduler functions. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/scheduler@0.12.0 (2017-08-24)
+
+#### :rocket: Enhancement
+* Other
+  * [#112](https://github.com/mostjs/core/pull/112) chore(ci): stop testing on node 4, to avoid npm 2. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#106](https://github.com/mostjs/core/pull/106) docs(api): Expand API docs. ([@briancavalier](https://github.com/briancavalier))
+* `disposable`
+  * [#110](https://github.com/mostjs/core/pull/110) feat(disposable): curry API. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`
+  * [#109](https://github.com/mostjs/core/pull/109) chore(lerna): update lerna to 2.0.0. Ignore problematic files. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`, `types`
+  * [#108](https://github.com/mostjs/core/pull/108) feat(scheduler): Add scheduler functions. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/types@0.11.0 (2017-08-24)
+
+#### :rocket: Enhancement
+* Other
+  * [#112](https://github.com/mostjs/core/pull/112) chore(ci): stop testing on node 4, to avoid npm 2. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#106](https://github.com/mostjs/core/pull/106) docs(api): Expand API docs. ([@briancavalier](https://github.com/briancavalier))
+* `disposable`
+  * [#110](https://github.com/mostjs/core/pull/110) feat(disposable): curry API. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `scheduler`
+  * [#109](https://github.com/mostjs/core/pull/109) chore(lerna): update lerna to 2.0.0. Ignore problematic files. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`, `types`
+  * [#108](https://github.com/mostjs/core/pull/108) feat(scheduler): Add scheduler functions. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/core@0.11.4 (2017-08-11)
+
+#### :rocket: Enhancement
+* `core`
+  * [#107](https://github.com/mostjs/core/pull/107) fix(debounce): ensure debounce disposes source. ([@briancavalier](https://github.com/briancavalier))
+
+#### :bug: Bug Fix
+* `core`
+  * [#107](https://github.com/mostjs/core/pull/107) fix(debounce): ensure debounce disposes source. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/core@0.11.3 (2017-08-01)
+
+#### :rocket: Enhancement
+* Other
+  * [#102](https://github.com/mostjs/core/pull/102) docs(api): add missing documentation. ([@TylorS](https://github.com/TylorS))
+  * [#104](https://github.com/mostjs/core/pull/104) docs(api): add sample docs. ([@davidchase](https://github.com/davidchase))
+  * [#101](https://github.com/mostjs/core/pull/101) docs(api): add documentation for tap and ap. ([@TylorS](https://github.com/TylorS))
+  * [#103](https://github.com/mostjs/core/pull/103) docs(api): minor fixes. ([@davidchase](https://github.com/davidchase))
+  * [#100](https://github.com/mostjs/core/pull/100) docs(api): Add propagatetask docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#98](https://github.com/mostjs/core/pull/98) docs(api): add continueWith, recoverWith, throwError docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#97](https://github.com/mostjs/core/pull/97) docs(api): zipArrayValues, withArrayValues, chain, and join. ([@TylorS](https://github.com/TylorS))
+* `core`
+  * [#99](https://github.com/mostjs/core/pull/99) refactor(PropagateTask): remove now-unused  arg from PropagateTaskRun. ([@briancavalier](https://github.com/briancavalier))
+
+#### :bug: Bug Fix
+* `core`
+  * [#105](https://github.com/mostjs/core/pull/105) fix(slice): Port fix from cujojs/most#468, simplify SettableDisposable. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 3
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- David Chase ([davidchase](https://github.com/davidchase))
+- Tylor Steinberger ([TylorS](https://github.com/TylorS))
+
+
+## @most/core@0.11.2 (2017-07-17)
+
+#### :rocket: Enhancement
+* Other
+  * [#96](https://github.com/mostjs/core/pull/96) docs(api): Add fromPromise, awaitPromises docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#94](https://github.com/mostjs/core/pull/94) docs(api): Add merge, combine, zip docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#95](https://github.com/mostjs/core/pull/95) test(ci): add travis node 8, remove node 7. ([@briancavalier](https://github.com/briancavalier))
+  * [#93](https://github.com/mostjs/core/pull/93) docs(api): Add delay, throttle, debounce docs. ([@briancavalier](https://github.com/briancavalier))
+  * [#92](https://github.com/mostjs/core/pull/92) docs(api): Add takeWhile, skipWhile, skipAfter docs. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#91](https://github.com/mostjs/core/pull/91) adds MulticastSource typings. ([@TylorS](https://github.com/TylorS))
+
+#### :bug: Bug Fix
+* `core`
+  * [#90](https://github.com/mostjs/core/pull/90) fix(skipAfter): export skipAfter. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 2
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+- Tylor Steinberger ([TylorS](https://github.com/TylorS))
+
+
+## @most/core@0.11.1 (2017-07-11)
+
+#### :bug: Bug Fix
+* `core`
+  * [#88](https://github.com/mostjs/core/pull/88) fix(at): export at. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/core@0.11.0 (2017-07-11)
+
+#### :rocket: Enhancement
+* Other
+  * [#86](https://github.com/mostjs/core/pull/86) docs(api): Add docs for a few sources. ([@briancavalier](https://github.com/briancavalier))
+  * [#84](https://github.com/mostjs/core/pull/84) docs(combinator-template): Add combinator doc template. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#87](https://github.com/mostjs/core/pull/87) feat(types): Add explicit covariance to allow custom types. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#81](https://github.com/mostjs/core/pull/81) chore(coverage): Enable nyc coverage in all packages. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#85](https://github.com/mostjs/core/pull/85) feat(runWithLocalTime): avoid nesting RelativeSinks. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/disposable@0.11.0 (2017-07-11)
+
+#### :rocket: Enhancement
+* Other
+  * [#86](https://github.com/mostjs/core/pull/86) docs(api): Add docs for a few sources. ([@briancavalier](https://github.com/briancavalier))
+  * [#84](https://github.com/mostjs/core/pull/84) docs(combinator-template): Add combinator doc template. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#87](https://github.com/mostjs/core/pull/87) feat(types): Add explicit covariance to allow custom types. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#81](https://github.com/mostjs/core/pull/81) chore(coverage): Enable nyc coverage in all packages. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#85](https://github.com/mostjs/core/pull/85) feat(runWithLocalTime): avoid nesting RelativeSinks. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/prelude@1.6.2 (2017-07-11)
+
+#### :rocket: Enhancement
+* Other
+  * [#86](https://github.com/mostjs/core/pull/86) docs(api): Add docs for a few sources. ([@briancavalier](https://github.com/briancavalier))
+  * [#84](https://github.com/mostjs/core/pull/84) docs(combinator-template): Add combinator doc template. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#87](https://github.com/mostjs/core/pull/87) feat(types): Add explicit covariance to allow custom types. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#81](https://github.com/mostjs/core/pull/81) chore(coverage): Enable nyc coverage in all packages. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#85](https://github.com/mostjs/core/pull/85) feat(runWithLocalTime): avoid nesting RelativeSinks. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/scheduler@0.11.0 (2017-07-11)
+
+#### :rocket: Enhancement
+* Other
+  * [#86](https://github.com/mostjs/core/pull/86) docs(api): Add docs for a few sources. ([@briancavalier](https://github.com/briancavalier))
+  * [#84](https://github.com/mostjs/core/pull/84) docs(combinator-template): Add combinator doc template. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#87](https://github.com/mostjs/core/pull/87) feat(types): Add explicit covariance to allow custom types. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#81](https://github.com/mostjs/core/pull/81) chore(coverage): Enable nyc coverage in all packages. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#85](https://github.com/mostjs/core/pull/85) feat(runWithLocalTime): avoid nesting RelativeSinks. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))
+
+
+## @most/types@0.10.0 (2017-07-11)
+
+#### :rocket: Enhancement
+* Other
+  * [#86](https://github.com/mostjs/core/pull/86) docs(api): Add docs for a few sources. ([@briancavalier](https://github.com/briancavalier))
+  * [#84](https://github.com/mostjs/core/pull/84) docs(combinator-template): Add combinator doc template. ([@briancavalier](https://github.com/briancavalier))
+* `scheduler`, `types`
+  * [#87](https://github.com/mostjs/core/pull/87) feat(types): Add explicit covariance to allow custom types. ([@briancavalier](https://github.com/briancavalier))
+* `core`, `disposable`, `prelude`, `scheduler`
+  * [#81](https://github.com/mostjs/core/pull/81) chore(coverage): Enable nyc coverage in all packages. ([@briancavalier](https://github.com/briancavalier))
+* `core`
+  * [#85](https://github.com/mostjs/core/pull/85) feat(runWithLocalTime): avoid nesting RelativeSinks. ([@briancavalier](https://github.com/briancavalier))
+
+#### Committers: 1
+- Brian Cavalier ([briancavalier](https://github.com/briancavalier))

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
-    "lerna": "^2.1.2"
+    "lerna": "^2.1.2",
+    "lerna-changelog": "^0.7.0"
   }
 }


### PR DESCRIPTION
I figured I'd give [lerna-changelog](https://github.com/lerna/lerna-changelog) a try for comparison with #164.  I npm installed it, created a GitHub token, and then ran:

```
lerna-changelog --tag-from '@most/prelude@1.6.1' > CHANGELOG.md
```

To generate the changelog from an old tag without any additional configuration options.  It doesn't seem to be very well documented yet, although [babel uses it](https://github.com/babel/babel/blob/master/package.json#L44) and looking at the [lerna-changelog config in their lerna.json](https://github.com/babel/babel/blob/master/lerna.json#L4-L15) is helpful.