### PR TITLE
Remove links to non-existent pages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,10 +24,3 @@ When *shouldn't* you use it?
    concepts
    api
    writing-docs
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
I think these were auto-generated or existed in whatever template I started with, but they're broken.  You can try them [here](http://mostcore.readthedocs.io/en/latest/index.html#indices-and-tables).