### PR TITLE
Correct the order of arguments in the sample combinator

### DIFF
--- a/packages/core/src/combinator/snapshot.js
+++ b/packages/core/src/combinator/snapshot.js
@@ -4,7 +4,7 @@ import Pipe from '../sink/Pipe'
 import { disposeBoth } from '@most/disposable'
 
 export const sample = (values, sampler) =>
-  snapshot((_, x) => x, values, sampler)
+  snapshot((x, _) => x, values, sampler)
 
 export const snapshot = (f, values, sampler) =>
   new Snapshot(f, values, sampler)


### PR DESCRIPTION
The sample combinator was taking values from the sampler stream instead of the values stream