### PR TITLE
Fix order of ap parameters

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -422,7 +422,7 @@ Apply the latest function in a :ref:`Stream` of functions to the latest value of
 
   streamOfFunctions:              --f-----------g---------h--------->
   stream:                         -a-------b---------c---------d---->
-  ap(stream, streamOfFunctions.): --f(a)---f(b)-g(b)-g(c)-h(c)-h(d)->
+  ap(streamOfFunctions, stream): --f(a)---f(b)-g(b)-g(c)-h(c)-h(d)->
 
 In effect, ``ap`` applies a time-varying function to a time-varying value.
 


### PR DESCRIPTION
The order of the parameters of `ap` was reversed in the docs.