### PR TITLE
Add disposable fusion

### DIFF
--- a/packages/disposable/src/disposeAll.js
+++ b/packages/disposable/src/disposeAll.js
@@ -1,13 +1,21 @@
-/** @license MIT License (c) copyright 2010-2017 original author or authors */
-import { reduce, curry2 } from '@most/prelude'
+/** @license MIT License (c) copyright 2010 original author or authors */
+import { append, reduce, curry2 } from '@most/prelude'
+import { disposeNone, isDisposeNone } from './disposeNone'
 
 // Aggregate a list of disposables into a DisposeAll
-export const disposeAll = ds =>
-  new DisposeAll(ds)
+export const disposeAll = ds => {
+  const merged = reduce(merge, [], ds)
+  return merged.length === 0 ? disposeNone() : new DisposeAll(merged)
+}
 
 // Convenience to aggregate 2 disposables
 export const disposeBoth = curry2((d1, d2) =>
   disposeAll([d1, d2]))
+
+const merge = (ds, d) =>
+  isDisposeNone(d) ? ds
+    : d instanceof DisposeAll ? ds.concat(d.disposables)
+    : append(d, ds)
 
 class DisposeAll {
   constructor (disposables) {

--- a/packages/disposable/src/disposeNone.js
+++ b/packages/disposable/src/disposeNone.js
@@ -4,3 +4,6 @@ export const disposeNone = () => NONE
 const NONE = new (class DisposeNone {
   dispose () {}
 })()
+
+export const isDisposeNone = d =>
+  d === NONE

--- a/packages/disposable/test/disposeAll-test.js
+++ b/packages/disposable/test/disposeAll-test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'mocha'
 import { eq, assert, throws } from '@briancavalier/assert'
 import { spy } from 'sinon'
+import { disposeNone, isDisposeNone } from '../src/disposeNone'
 import { disposeAll, disposeBoth, DisposeAllError } from '../src/disposeAll'
 
 const noop = () => {}
@@ -27,6 +28,22 @@ describe('disposeAll', () => {
       const disposables = disposableSpies()
       disposeAll(disposables).dispose()
       assertAllDisposed(disposables)
+    })
+
+    it('should fuse disposeNone', () => {
+      const d = disposeAll([disposeNone(), disposeNone()])
+      assert(isDisposeNone(d))
+    })
+
+    it('should fuse disposeAll', () => {
+      const d1 = disposableSpies()
+      const d2 = disposableSpies()
+
+      const d = disposeAll([disposeAll(d1), disposeAll(d2)])
+      eq(d1.length + d2.length, d.disposables.length)
+
+      d.dispose()
+      assertAllDisposed(d1.concat(d2))
     })
 
     it('should dispose all and aggregate errors', function () {

--- a/packages/disposable/test/disposeNone-test.js
+++ b/packages/disposable/test/disposeNone-test.js
@@ -1,9 +1,21 @@
 import { describe, it } from 'mocha'
-import { is } from '@briancavalier/assert'
-import { disposeNone } from '../src/disposeNone'
+import { assert, is } from '@briancavalier/assert'
+import { disposeNone, isDisposeNone } from '../src/disposeNone'
 
 describe('disposeNone', () => {
-  it('should return same instance', () => {
-    is(disposeNone(), disposeNone())
+  describe('disposeNone', () => {
+    it('should return same instance', () => {
+      is(disposeNone(), disposeNone())
+    })
+  })
+
+  describe('isDisposeNone', () => {
+    it('should be true for disposeNone', () => {
+      assert(isDisposeNone(disposeNone()))
+    })
+
+    it('should be false for non-disposeNone', () => {
+      assert(!isDisposeNone({ dispose () {} }))
+    })
   })
 })


### PR DESCRIPTION
Add disposable fusion for disposeAll and disposeNone.

This allows disposeAll to:
1. filter out disposeNone
2. return disposeNone if after filtering out disposeNone, it ends up with an array of length zero.  This has the additional benefit of making `disposeAll([])` return disposeNone.
3. recognize nested disposeAll, and flatten them into a single array, also recursively applying 1 and 2.  This will flatten an entire tree of disposables as far as possible by flattening arrays and removing disposeNone.

See also #216 