### PR TITLE
Allow merge to produce union

### DIFF
--- a/packages/core/.flowconfig
+++ b/packages/core/.flowconfig
@@ -1,10 +1,11 @@
 [ignore]
 .*/node_modules/conventional-changelog-core/.*
+test/perf/.*
 
 [include]
 ../../node_modules
-test/
-test/flow/**/*.js
+test/.*\.js
+test/flow/*.\.js
 dist/.*\.flow
 
 [libs]

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -73,8 +73,8 @@ declare export function continueWith <A> (f: (any) => Stream<A>): (s: Stream<A>)
 
 declare export function switchLatest <A> (s: Stream<Stream<A>>): Stream<A>
 
-declare export function merge <A> (s1: Stream<A>, s2: Stream<A>): Stream<A>
-declare export function merge <A> (s1: Stream<A>): (s2: Stream<A>) => Stream<A>
+declare export function merge <A, B> (s1: Stream<A>, s2: Stream<B>): Stream<A | B>
+declare export function merge <A, B> (s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
 declare export function mergeArray <A> (ss: Array<Stream<A>>): Stream<A>
 
 declare export function sample <A> (values: Stream<A>, sampler: Stream<any>): Stream<A>

--- a/packages/core/test/flow/combinator/merge.js
+++ b/packages/core/test/flow/combinator/merge.js
@@ -1,0 +1,10 @@
+// @flow
+import { merge, now, runEffects } from '../../../src/index'
+import { type Stream } from '@most/types'
+import { newDefaultScheduler } from '@most/scheduler'
+
+const s1 = now(123)
+const s2 = now('a')
+const s = merge(s1, s2)
+
+runEffects(s, newDefaultScheduler())

--- a/packages/core/type-definitions/combinator/merge.d.ts
+++ b/packages/core/type-definitions/combinator/merge.d.ts
@@ -1,5 +1,5 @@
 import { Stream } from '@most/types';
 
-export function merge<A>(s1: Stream<A>, s2: Stream<A>): Stream<A>;
-export function merge<A>(s1: Stream<A>): (s2: Stream<A>) => Stream<A>
+export function merge<A, B>(s1: Stream<A>, s2: Stream<B>): Stream<A | B>;
+export function merge<A, B>(s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
 export function mergeArray<A>(streams: Array<Stream<A>>): Stream<A>;


### PR DESCRIPTION
As per recent discussion, this loosens the type of the 2-stream `merge` to accept streams of different types and produce a stream of the union.

At first, this might seem unsafe because you might accidentally call merge with different types, say `A` and `B` when you didn't mean to.  However, since the resulting stream has a union type, `A | B`, when you try to use it, for example by mapping it with a function `A => C`, the type checker will prevent it.  Thus, I believe this is entirely safe, while adding some flexibility for situations where you might actually want to construct a union. 