### PR TITLE
Refactor VirtualTimer and expose it in scheduler package

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -150,6 +150,19 @@ Timer
 
 A ``Timer`` abstracts platform time, typically relying on a :ref:`Clock`, and timer scheduling, typically using ``setTimeout``.
 
+.. _VirtualTimer:
+
+VirtualTimer
+^^^^^
+
+.. code-block:: haskell
+
+  type VirtualTimer = {
+    tick :: (Offset) -> void
+  }
+
+A ``VirtualTimer`` is a :ref:`Timer` with a tick function for progressing the Timer's time.
+
 .. _Timeline:
 
 Timeline
@@ -1371,6 +1384,24 @@ newClockTimer
   newClockTimer :: Clock -> Timer
 
 Create a new :ref:`Timer` that uses the provided :ref:`Clock` as a source of the current :ref:`Time`.
+
+.. _newVirtualTimer:
+
+newVirtualTimer
+`````````````
+
+.. code-block:: haskell
+
+  newVirtualTimer :: () -> VirtualTimer
+
+Create a new :ref:`VirtualTimer` that you can progress its time manually. Used mainly for testing.
+
+.. code-block:: javascript
+
+  const timer = newVirtualTimer()
+  console.log(timer.now()) // 0
+  timer.tick(10);
+  console.log(timer.now()) // 10
 
 .. _newTimeline:
 

--- a/packages/scheduler/src/VirtualTimer.js
+++ b/packages/scheduler/src/VirtualTimer.js
@@ -1,0 +1,60 @@
+/** @license MIT License (c) copyright 2010-2018 original author or authors */
+
+export default function newVirtualTimer () {
+  let nows = 0
+  let targetNow = 0
+  let task
+  let timer = null
+  let running = false
+  const key = {}
+
+  function stepTimer () {
+    if (nows >= targetNow) {
+      nows = targetNow
+      running = false
+      return
+    }
+    if (task !== undefined && targetNow >= task.time) {
+      nows = task.time
+    } else {
+      nows = targetNow
+    }
+    if (task !== undefined && nows === task.time) {
+      const fn = task.fn
+      task = undefined
+      if (typeof fn === 'function') {
+        fn()
+      }
+    }
+    timer = setTimeout(stepTimer, 0)
+  }
+
+  return {
+    now: () => nows,
+    setTimer: function (fn, dt) {
+      if (task !== undefined) {
+        throw new Error('VirtualTimer: Only supports one in-flight timer')
+      }
+      task = {fn, time: nows + Math.max(0, dt)}
+      return key
+    },
+    clearTimer: function (t) {
+      if (t !== key) {
+        return
+      }
+      clearTimeout(timer)
+      task = undefined
+    },
+    tick: function (dt) {
+      if (dt <= 0) {
+        return
+      }
+      targetNow = nows + dt
+      if (running) {
+        return
+      }
+      running = true
+      timer = setTimeout(stepTimer, 0)
+    }
+  }
+}

--- a/packages/scheduler/src/index.js
+++ b/packages/scheduler/src/index.js
@@ -6,6 +6,7 @@ import Scheduler from './Scheduler'
 import Timeline from './Timeline'
 import ClockTimer from './ClockTimer'
 import { newPlatformClock } from './clock'
+import newVirtualTimer from './VirtualTimer'
 
 export * from './clock'
 export * from './schedule'
@@ -17,5 +18,6 @@ export const newDefaultScheduler = () => new Scheduler(newDefaultTimer(), new Ti
 
 export const newDefaultTimer = () => new ClockTimer(newPlatformClock())
 export const newClockTimer = clock => new ClockTimer(clock)
+export { newVirtualTimer }
 
 export const newTimeline = () => new Timeline()

--- a/packages/scheduler/src/index.js.flow
+++ b/packages/scheduler/src/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Clock, Time, Delay, Period, Offset } from '@most/types'
+import type { Scheduler, Task, ScheduledTask, Timeline, Timer, Clock, Time, Delay, Period, Offset, VirtualTimer } from '@most/types'
 
 declare export function newScheduler (timer: Timer, timeline: Timeline): Scheduler
 declare export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler
@@ -10,6 +10,7 @@ declare export function schedulerRelativeTo (offset: Offset, scheduler: Schedule
 declare export function schedulerRelativeTo (offset: Offset): (scheduler: Scheduler) => Scheduler
 
 declare export function newClockTimer (clock: Clock): Timer
+declare export function newVirtualTimer (): VirtualTimer
 declare export function newTimeline (): Timeline
 
 declare export function newPlatformClock (): Clock

--- a/packages/scheduler/test/VirtualTimer-test.js
+++ b/packages/scheduler/test/VirtualTimer-test.js
@@ -1,0 +1,62 @@
+// @flow
+import { describe, it } from 'mocha'
+import { eq, AssertionError } from '@briancavalier/assert'
+
+import newVirtualTimer from '../src/VirtualTimer'
+
+describe('VirtualTimer', () => {
+  it('new timer should start at time: 0', () => {
+    const timer = newVirtualTimer()
+    eq(0, timer.now())
+  })
+
+  it('should expose a tick function', () => {
+    const timer = newVirtualTimer()
+    eq('function', typeof timer.tick)
+  })
+
+  it('should trigger timer upon ticking', () => {
+    const timer = newVirtualTimer()
+    const dt = 234
+    return new Promise(resolve => {
+      timer.setTimer(() => resolve(eq(timer.now(), dt)), dt)
+      timer.tick(dt)
+    })
+  })
+
+  it('should not trigger timer time upon ticking to an earlier time', () => {
+    const timer = newVirtualTimer()
+    const dt = 234
+    return new Promise((resolve, reject) => {
+      timer.setTimer(() => {
+        console.log('triggered')
+        reject(new AssertionError('Timer triggered when it should not'))
+      }, dt + 1)
+      timer.tick(dt)
+      setTimeout(resolve(), 0)
+    })
+  })
+
+  it('should not trigger timer when we do not tick manually', () => {
+    const timer = newVirtualTimer()
+    const dt = 234
+    return new Promise((resolve, reject) => {
+      timer.setTimer(() => {
+        console.log('triggered')
+        reject(new AssertionError('Timer triggered when it should not'))
+      }, dt + 1)
+      setTimeout(resolve(), 0)
+    })
+  })
+
+  it('should push current time to requested value if timer is set after that time', () => {
+    const timer = newVirtualTimer()
+    const dt = 243
+    const taskTime = dt + 10
+    return new Promise(resolve => {
+      timer.setTimer(() => undefined, taskTime)
+      timer.tick(dt)
+      setTimeout(() => resolve(eq(timer.now(), dt)), 0)
+    })
+  })
+})

--- a/packages/scheduler/type-definitions/index.d.ts
+++ b/packages/scheduler/type-definitions/index.d.ts
@@ -1,4 +1,4 @@
-import { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Clock, Delay, Period, Offset } from '@most/types';
+import { Scheduler, Task, ScheduledTask, Timeline, Timer, Time, Clock, Delay, Period, Offset, VirtualTimer } from '@most/types';
 
 export function newScheduler (timer: Timer, timeline: Timeline): Scheduler;
 export function newScheduler (timer: Timer): (timeline: Timeline) => Scheduler;
@@ -9,6 +9,7 @@ export function schedulerRelativeTo (offset: Offset, scheduler: Scheduler): Sche
 export function schedulerRelativeTo (offset: Offset): (scheduler: Scheduler) => Scheduler
 
 export function newClockTimer (clock: Clock): Timer;
+export function newVirtualTimer (): VirtualTimer;
 export function newTimeline (): Timeline;
 
 export function newPlatformClock (): Clock;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -74,3 +74,7 @@ export interface ScheduledTask {
   error(err: Error): void;
   dispose(): void;
 }
+
+export interface VirtualTimer extends Timer {
+  tick(dt: Offset): void;
+}

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -78,3 +78,7 @@ export type ScheduledTask = Disposable & {
   run (): void,
   error (Error): void,
 }
+
+export type VirtualTimer = Timer & {
+  tick (Offset): void
+}


### PR DESCRIPTION
Hello since this is my first commit please review carefully and let me know for any mess ups. As the title says I exposed `VirtualTimer` on the `@most/scheduler` package and updated the types (flow and typescript) and the docs.

Apart from the refactoring I did on `VirtualTimer` I have changed some behavior in it that I found puzzling at least for me. So please verify if the new behavior is the **wanted one**.

More specifically

- when we had a `setTimer()` with a `dt` > than the `dt` specified in the `tick()` invocation the timers `now()` time progressed at the `dt` of the `setTimer()` and the set function was also called.
- Also during the invocation of the `fn` given to the `setTimer` the `timer.now()` returned `Infinity`

both above behaviors are now changed so 

- calling `tick()` is going to result to forwarding the time at the `dt` specified in that invocation (calling the `fn` set with `setTimer` if its `dt` is passed)
- Also during invocation of a `setTimer` `fn` the `timer.now()` returns the correct time

As a test I replaced the old `VirtualTimer` on the `@most/core` tests and run the tests with success, so I guess that the behavior that I have changed was not something that a test was relying on.