### PR TITLE
fix for reduce helper test function

### DIFF
--- a/packages/core/test/helper/reduce.js
+++ b/packages/core/test/helper/reduce.js
@@ -2,7 +2,6 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-import Pipe from '../../src/sink/Pipe'
 import { runEffects } from '../../src/runEffects'
 import { tap } from '../../src/combinator/transform'
 import { newDefaultScheduler } from '@most/scheduler'
@@ -18,36 +17,6 @@ import { newDefaultScheduler } from '@most/scheduler'
 */
 export function reduce (f, initial, stream) {
   let result = initial
-  const source = tap(x => { result = x }, new Reduce(f, initial, stream))
+  const source = tap(x => { result = x }, stream)
   return runEffects(source, newDefaultScheduler()).then(() => result)
-}
-
-class Reduce {
-  constructor (f, z, source) {
-    this.source = source
-    this.f = f
-    this.value = z
-  }
-
-  run (sink, scheduler) {
-    return this.source.run(new ReduceSink(this.f, this.value, sink), scheduler)
-  }
-}
-
-class ReduceSink extends Pipe {
-  constructor (f, z, sink) {
-    super(sink)
-    this.f = f
-    this.value = z
-  }
-
-  event (t, x) {
-    const f = this.f
-    this.value = f(this.value, x)
-    this.sink.event(t, this.value)
-  }
-
-  end (t) {
-    this.sink.end(t, this.value)
-  }
 }

--- a/packages/core/test/helper/reduce.js
+++ b/packages/core/test/helper/reduce.js
@@ -4,6 +4,7 @@
 
 import Pipe from '../../src/sink/Pipe'
 import { runEffects } from '../../src/runEffects'
+import { tap } from '../../src/combinator/transform'
 import { newDefaultScheduler } from '@most/scheduler'
 
 /**
@@ -13,10 +14,13 @@ import { newDefaultScheduler } from '@most/scheduler'
 * @param {function(result:*, x:*):*} f reducer function
 * @param {*} initial initial value
 * @param {Stream} stream to reduce
-* @returns {Promise} promise for the file result of the reduce
+* @returns {Promise} promise for the final result of the reduce
 */
-export const reduce = (f, initial, stream) =>
-  runEffects(new Reduce(f, initial, stream), newDefaultScheduler())
+export function reduce (f, initial, stream) {
+  let result = initial
+  const source = tap(x => { result = x }, new Reduce(f, initial, stream))
+  return runEffects(source, newDefaultScheduler()).then(() => result)
+}
 
 class Reduce {
   constructor (f, z, source) {


### PR DESCRIPTION
while working on `@most/test` I found an error on this function. Thankfully it did not affect the validity of the tests. This solves two problems:

- Promise always returned `undefined` instead of the final value
- If the initial value was a primitive (ie. not passed by reference) the result would be the initial value
