### PR TITLE
Proposal: Sink event callbacks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,9 +79,9 @@ Sink
 .. code-block:: haskell
 
   type Sink a = {
-    event :: Time -> a -> void
-    error :: Time -> Error -> void
-    end :: Time -> void
+    event :: Time -> a -> mixed
+    error :: Time -> Error -> mixed
+    end :: Time -> mixed
   }
 
 A ``Sink`` receives events—typically it does something with them, such as transforming or filtering them—and then propagates them to another ``Sink``.

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -12,9 +12,9 @@ export interface Stream<A> {
   run (sink: Sink<A>, scheduler: Scheduler): Disposable;
 }
 
-export type sinkEventCallback<A> = (time?: Time, value?: A) => mixed
-export type sinkEndCallback = (time?: Time) => mixed
-export type sinkErrorCallback = (time?: Time, error?: Error) => mixed
+export type sinkEventCallback<A> = (time?: Time, value?: A) => any
+export type sinkEndCallback = (time?: Time) => any
+export type sinkErrorCallback = (time?: Time, error?: Error) => any
 
 export interface Sink<A> {
   event: sinkEventCallback<A>;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -12,10 +12,14 @@ export interface Stream<A> {
   run (sink: Sink<A>, scheduler: Scheduler): Disposable;
 }
 
+export type sinkEventCallback<A> = (time?: Time, value?: A) => mixed
+export type sinkEndCallback = (time?: Time) => mixed
+export type sinkErrorCallback = (time?: Time, error?: Error) => mixed
+
 export interface Sink<A> {
-  event(time: Time, value: A): void;
-  end(time: Time): void;
-  error(time: Time, err: Error): void;
+  event: sinkEventCallback<A>;
+  end: sinkEndCallback;
+  error: sinkErrorCallback;
 }
 
 // Interface of a resource that can be disposed

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -14,10 +14,14 @@ export type Stream<A> = {
   run (Sink<A>, Scheduler): Disposable
 }
 
+declare export function sinkEventCallback<A>(time?: Time, value?: A): mixed
+declare export function sinkEndCallback(time?: Time): mixed
+declare export function sinkErrorCallback(time?: Time, error?: Error): mixed
+
 export type Sink<A> = {
-  event (Time, A): void,
-  end (Time): void,
-  error (Time, Error): void,
+  event: sinkEventCallback<A>,
+  end: sinkEndCallback,
+  error: sinkErrorCallback,
 }
 
 // Interface of a resource that can be disposed


### PR DESCRIPTION
I think it would be better to relax the return values of the sink callback functions and also expose them as types

Thoughts?