### PR TITLE
Update merge docs to show union return type

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -637,7 +637,7 @@ merge
 
 .. code-block:: haskell
 
-  merge :: Stream a -> Stream a -> Stream a
+  merge :: Stream a -> Stream b -> Stream (a | b)
 
 Create a new :ref:`Stream` containing events from two :ref:`Streams <Stream>`. ::
 


### PR DESCRIPTION
Follow up to #224, which didn't include the doc update.