### PR TITLE
Deprecate Scheduler cancelAllTasks and supporting functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -113,6 +113,7 @@ Scheduler
     scheduleTask :: Offset -> Delay -> Period -> Task -> ScheduledTask
     relative :: Offset -> Scheduler
     cancel :: ScheduledTask -> void
+    -- deprecated
     cancelAll :: (ScheduledTask -> boolean) -> void
   }
 
@@ -162,6 +163,7 @@ Timeline
   type Timeline = {
     add :: ScheduledTask -> void,
     remove :: ScheduledTask -> boolean,
+    -- deprecated
     removeAll :: (ScheduledTask) -> boolean) -> void,
     isEmpty :: () -> boolean,
     nextArrival :: () -> Time,
@@ -1302,6 +1304,8 @@ Cancel all future scheduled executions of a :ref:`ScheduledTask`.
 
 cancelAllTasks
 ``````````````
+
+.. warning:: **Deprecated**: Instead of using cancelAllTasks, Scheduler callers should track the tasks they create (e.g. by storing them in an array or other data structure), and then canceling each explicitly using :ref:`cancelTask`.
 
 .. code-block:: haskell
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1305,7 +1305,7 @@ Cancel all future scheduled executions of a :ref:`ScheduledTask`.
 cancelAllTasks
 ``````````````
 
-.. warning:: **Deprecated**: Instead of using cancelAllTasks, Scheduler callers should track the tasks they create (e.g. by storing them in an array or other data structure), and then canceling each explicitly using :ref:`cancelTask`.
+.. warning:: **Deprecated**: Instead of using cancelAllTasks, Scheduler callers should track the tasks they create (e.g. by storing them in an array or other data structure), and then cancel each explicitly using :ref:`cancelTask`.
 
 .. code-block:: haskell
 

--- a/packages/core/src/combinator/delay.js
+++ b/packages/core/src/combinator/delay.js
@@ -4,7 +4,7 @@
 
 import Pipe from '../sink/Pipe'
 import { disposeBoth } from '@most/disposable'
-import { cancelAllTasks, delay as scheduleDelay } from '@most/scheduler'
+import { cancelTask, delay as scheduleDelay } from '@most/scheduler'
 import { propagateEndTask, propagateEventTask } from '../scheduler/PropagateTask'
 
 /**
@@ -32,17 +32,18 @@ class DelaySink extends Pipe {
     super(sink)
     this.dt = dt
     this.scheduler = scheduler
+    this.tasks = []
   }
 
   dispose () {
-    cancelAllTasks(({ task }) => task.sink === this.sink, this.scheduler)
+    this.tasks.forEach(cancelTask)
   }
 
   event (t, x) {
-    scheduleDelay(this.dt, propagateEventTask(x, this.sink), this.scheduler)
+    this.tasks.push(scheduleDelay(this.dt, propagateEventTask(x, this.sink), this.scheduler))
   }
 
   end (t) {
-    scheduleDelay(this.dt, propagateEndTask(this.sink), this.scheduler)
+    this.tasks.push(scheduleDelay(this.dt, propagateEndTask(this.sink), this.scheduler))
   }
 }

--- a/packages/core/src/source/at.js
+++ b/packages/core/src/source/at.js
@@ -5,7 +5,7 @@ import { delay } from '@most/scheduler'
 
 export const at = (t, x) => new At(t, x)
 
-class At {
+export class At {
   constructor (t, x) {
     this.time = t
     this.value = x

--- a/packages/prelude/src/array.js
+++ b/packages/prelude/src/array.js
@@ -145,6 +145,7 @@ function unsafeRemove (i, a, l) {
 
 // removeAll :: (a -> boolean) -> [a] -> [a]
 // remove all elements matching a predicate
+// @deprecated
 export function removeAll (f, a) {
   const l = a.length
   const b = new Array(l)

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -39,6 +39,7 @@ export default class Scheduler {
     }
   }
 
+  // @deprecated
   cancelAll (f) {
     this.timeline.removeAll(f)
     this._reschedule()

--- a/packages/scheduler/src/Timeline.js
+++ b/packages/scheduler/src/Timeline.js
@@ -33,6 +33,7 @@ export default class Timeline {
     return false
   }
 
+  // @deprecated
   removeAll (f) {
     for (let i = 0; i < this.tasks.length; ++i) {
       removeAllFrom(f, this.tasks[i])
@@ -124,6 +125,7 @@ function getTime (scheduledTask) {
   return Math.floor(scheduledTask.time)
 }
 
+// @deprecated
 function removeAllFrom (f, timeslot) {
   timeslot.events = removeAll(f, timeslot.events)
 }

--- a/packages/scheduler/src/schedule.js
+++ b/packages/scheduler/src/schedule.js
@@ -24,5 +24,6 @@ export const cancelTask = scheduledTask =>
 
 // Cancel all ScheduledTasks for which a predicate
 // is true
+// @deprecated
 export const cancelAllTasks = curry2((predicate, scheduler) =>
   scheduler.cancelAll(predicate))

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -37,6 +37,7 @@ export interface Scheduler {
   scheduleTask (offset: Offset, delay: Delay, period: Period, task: Task): ScheduledTask;
   relative(offset: Offset): Scheduler;
   cancel(task: ScheduledTask): void;
+  // @deprecated
   cancelAll(predicate: (task: ScheduledTask) => boolean): void;
 }
 
@@ -56,6 +57,7 @@ export type TaskRunner = (st: ScheduledTask) => any;
 export interface Timeline {
   add(scheduledTask: ScheduledTask): void;
   remove(scheduledTask: ScheduledTask): boolean;
+  // @deprecated
   removeAll(f: (scheduledTask: ScheduledTask) => boolean): void;
   isEmpty(): boolean;
   nextArrival(): Time;

--- a/packages/types/index.js.flow
+++ b/packages/types/index.js.flow
@@ -39,6 +39,7 @@ export type Scheduler = {
   scheduleTask (Offset, Delay, Period, Task): ScheduledTask,
   relative (Offset): Scheduler,
   cancel (ScheduledTask): void,
+  // @deprecated
   cancelAll ((ScheduledTask) => boolean): void
 }
 
@@ -62,6 +63,7 @@ export type TaskRunner = (ScheduledTask) => any
 export type Timeline = {
   add (ScheduledTask): void,
   remove (ScheduledTask): boolean,
+  // @deprecated
   removeAll ((ScheduledTask) => boolean): void,
   isEmpty (): boolean,
   nextArrival (): Time,


### PR DESCRIPTION
Deprecate cancelAllTasks and all supporting functions that were called only from it.  Change the implementation of delay so that it no longer uses cancelAllTasks.

Afaict, cancelAllTasks is only called by DelaySink.  It seems simpler to deprecate it and just track tasks directly in DelaySink.