### PR TITLE
Add getting started section

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,13 +1,17 @@
 FAQ
 ===
 
-**Q: What's the relationship between most 1.0 and @most/core?**
+**Q: What's the relationship between most 1.x and @most/core?**
 
 A: ``@most/core`` is a new implementation of most's architecture, based on lessons learned from building and maintaining most. It has a leaner API that is more tailored to a functional style of programming.
 
 Most 2.0 will be implemented on top of @most/core.
 
 If you're starting a new project and @most/core's leaner API and programming style fit your goals, we recommend starting with it rather than most.
+
+**Q: How do I upgrade from most 1.x to @most/core?**
+
+See the :doc:`upgrading-guide`.
 
 **Q: I want to process Arrays / time series data. Should I use ``@most/core`` for that?**
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,14 @@
+Getting Started
+===============
+
+Getting started with `@most/core`
+
+Install
+-------
+
+npm i --save @most/core @most/scheduler
+
+yarn add @most/core @most/scheduler
+
+Examples
+--------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -24,5 +24,5 @@ See the :doc:`upgrading-guide`.
 Examples
 --------
 
-1. `@most/core Examples repo <https://github.com/mostjs/examples>`_
-1. `TodoMVC <https://github.com/briancavalier/mostcore-todomvc>`_ with ``@most/core`` and React
+#. `@most/core Examples repo <https://github.com/mostjs/examples>`_
+#. `TodoMVC <https://github.com/briancavalier/mostcore-todomvc>`_ with ``@most/core`` and React

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,14 +1,28 @@
 Getting Started
 ===============
 
-Getting started with `@most/core`
+Getting started with ``@most/core``
 
 Install
 -------
 
-npm i --save @most/core @most/scheduler
+.. code-block:: bash
 
-yarn add @most/core @most/scheduler
+  npm i --save @most/core @most/scheduler
+
+Flow and Typescript users should also install the top-level types:
+
+.. code-block:: bash
+
+  npm i --save @most/types
+
+Upgrading to ``@most/core`` from ``most``
+-----------------------------------------
+
+See the :doc:`upgrading-guide`.
 
 Examples
 --------
+
+1. `@most/core Examples repo <https://github.com/mostjs/examples>`_
+1. `TodoMVC <https://github.com/briancavalier/mostcore-todomvc>`_ with ``@most/core`` and React

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ When *shouldn't* you use it?
    :caption: Contents:
 
    faq
+   getting-started
    notation
    concepts
    api

--- a/docs/upgrading-guide.rst
+++ b/docs/upgrading-guide.rst
@@ -1,0 +1,4 @@
+Upgrading to @most/core from most 1.x
+=====================================
+
+*Coming soon*


### PR DESCRIPTION
Add a simple Getting Started section with install instructions, links to examples, and link to stub doc for upgrading from most 1.x.  My intent is to get something simple in place that we can expand as necessary.  The upgrading doc is just a stub, but gives us a place to start writing.