### PR TITLE
Deprecate newDateClock

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1425,6 +1425,8 @@ Create a new :ref:`Clock` using ``process.hrtime``.
 newDateClock
 ````````````
 
+.. warning:: **Deprecated**: Will be removed in 2.0.0.  ``Date.now`` is not monotonic, and has only been supported as a fallback for browsers that don't support ``performance.now``.
+
 .. code-block:: haskell
 
   newDateClock :: () -> Clock

--- a/packages/scheduler/src/clock.js
+++ b/packages/scheduler/src/clock.js
@@ -31,6 +31,9 @@ export const clockRelativeTo = clock =>
 export const newPerformanceClock = () =>
   clockRelativeTo(performance)
 
+// @deprecated will be removed in 2.0.0
+// Date.now is not monotonic, and performance.now is ubiquitous:
+// See https://caniuse.com/#search=performance.now
 export const newDateClock = () =>
   clockRelativeTo(Date)
 


### PR DESCRIPTION
Since, [`performance.now` is ubiquitous](https://caniuse.com/#search=performance.now), we can deprecate the Date-based clock, which wasn't monotonic to begin with.