### PR TITLE
Fix run docs return type, add note about declarative vs imperative

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -227,11 +227,15 @@ Activate an event :ref:`Stream` and consume all its events.
 run
 ```
 
+.. attention:: ``@most/core`` encourages a declarative approach.  Combinators like :ref:`until` allow you to declare which events you're interested in, and ``@most/core`` will manage acquiring and disposing resources automatically.  ``run`` is intended for use cases that cannot be handled declaratively, such as at integration points with other projects whose APIs may force an imperative approach.
+
 .. code-block:: haskell
 
-  run :: Sink a -> Scheduler -> Stream a -> void
+  run :: Sink a -> Scheduler -> Stream a -> Disposable
 
-Run a :ref:`Stream`, sending all events to the provided :ref:`Sink`.  The Stream's :ref:`Time` values come from the provided :ref:`Scheduler`.
+Run a :ref:`Stream`, sending all events to the provided :ref:`Sink`.  The Stream's :ref:`Time` values come from the provided :ref:`Scheduler`.  Returns a :ref:`Disposable` that can be used to dispose underlying resources imperatively.
+
+Declarative combinators like :ref:`until` still manage resources automatically when using ``run``.  The returned :ref:`Disposable` simply provides an `additional` way to trigger disposal manually.
 
 Construction
 ^^^^^^^^^^^^


### PR DESCRIPTION
See #266

`run` returns `Disposable`.  It's correct in code and type definitions, but was incorrectly documented as `void` in the API docs.  This fixes the docs and adds a note to emphasize `@most/core`'s declarative approach, and to provide guidance on use cases where `run` and it's returned `Disposable` may be necessary.