### PR TITLE
Simplify until/since and fix subtle until dispose bug

### DIFF
--- a/packages/core/test/timeslice-test.js
+++ b/packages/core/test/timeslice-test.js
@@ -7,14 +7,15 @@ import { periodic } from '../src/source/periodic'
 import { now } from '../src/source/now'
 import { never } from '../src/source/never'
 import { delay } from '../src/combinator/delay'
+import { run } from '../src/run'
 
 import { ticks, collectEvents, collectEventsFor, makeEvents } from './helper/testEnv'
 import FakeDisposeStream from './helper/FakeDisposeStream'
 
 import { spy } from 'sinon'
 
-describe('during', function () {
-  it('should contain events at or later than min and earlier than max', function () {
+describe('during', () => {
+  it('should contain events at or later than min and earlier than max', () => {
     const stream = take(10, periodic(1))
     const timespan = delay(1, now(delay(5, now())))
 
@@ -29,7 +30,7 @@ describe('during', function () {
       ]))
   })
 
-  it('should dispose source stream', function () {
+  it('should dispose source stream', () => {
     const dispose = spy()
     const stream = FakeDisposeStream.from(dispose, periodic(1))
     const timespan = delay(1, now(delay(5, now())))
@@ -39,7 +40,7 @@ describe('during', function () {
       .then(() => assert(dispose.calledOnce))
   })
 
-  it('should dispose signals', function () {
+  it('should dispose signals', () => {
     const dispose = spy()
 
     const stream = periodic(1)
@@ -55,8 +56,8 @@ describe('during', function () {
   })
 })
 
-describe('until', function () {
-  it('should only contain events earlier than signal', function () {
+describe('until', () => {
+  it('should only contain events earlier than signal', () => {
     const stream = makeEvents(1, 10)
     const signal = delay(3, now())
 
@@ -70,7 +71,7 @@ describe('until', function () {
       ]))
   })
 
-  it('should dispose source stream', function () {
+  it('should dispose source stream', () => {
     const dispose = spy()
     const stream = FakeDisposeStream.from(dispose, periodic(1))
     const signal = delay(3, now())
@@ -80,7 +81,7 @@ describe('until', function () {
       .then(() => assert(dispose.calledOnce))
   })
 
-  it('should end immediately on signal', function () {
+  it('should end immediately on signal', () => {
     const dispose = spy()
     const stream = FakeDisposeStream.from(dispose, never())
     const signal = now()
@@ -93,7 +94,7 @@ describe('until', function () {
       })
   })
 
-  it('should dispose signal', function () {
+  it('should dispose signal', () => {
     const dispose = spy()
     const stream = periodic(1)
     const signal = FakeDisposeStream.from(dispose, delay(3, now()))
@@ -109,10 +110,23 @@ describe('until', function () {
         assert(dispose.calledOnce)
       })
   })
+
+  it('should dispose with run', (done) => {
+    // See https://github.com/mostjs/core/issues/266#issuecomment-459485449
+    const stream = periodic(1)
+    const signal = FakeDisposeStream.from(done, delay(3, now()))
+
+    const s = until(signal, stream)
+    run({
+      event () {},
+      error () {},
+      end () {}
+    }, ticks(5), s)
+  })
 })
 
-describe('since', function () {
-  it('should only contain events at or later than signal', function () {
+describe('since', () => {
+  it('should only contain events at or later than signal', () => {
     const n = 5
     const stream = take(n, periodic(1))
     const signal = delay(3, now())
@@ -125,7 +139,7 @@ describe('since', function () {
       ]))
   })
 
-  it('should dispose signal', function () {
+  it('should dispose signal', () => {
     const dispose = spy()
     const stream = take(5, periodic(1))
     const signal = FakeDisposeStream.from(dispose, delay(3, now()))

--- a/packages/scheduler/src/ScheduledTask.js
+++ b/packages/scheduler/src/ScheduledTask.js
@@ -19,6 +19,7 @@ export default class ScheduledTask {
   }
 
   dispose () {
+    this.active = false
     this.scheduler.cancel(this)
     return this.task.dispose()
   }

--- a/packages/scheduler/src/Timeline.js
+++ b/packages/scheduler/src/Timeline.js
@@ -23,10 +23,11 @@ export default class Timeline {
     const i = binarySearch(getTime(st), this.tasks)
 
     if (i >= 0 && i < this.tasks.length) {
-      const at = findIndex(st, this.tasks[i].events)
+      const events = this.tasks[i].events
+      const at = findIndex(st, events)
       if (at >= 0) {
-        this.tasks[i].events.splice(at, 1)
-        if (this.tasks[i].events.length === 0) {
+        events.splice(at, 1)
+        if (events.length === 0) {
           this.tasks.splice(i, 1)
         }
         return true

--- a/packages/scheduler/src/Timeline.js
+++ b/packages/scheduler/src/Timeline.js
@@ -26,6 +26,9 @@ export default class Timeline {
       const at = findIndex(st, this.tasks[i].events)
       if (at >= 0) {
         this.tasks[i].events.splice(at, 1)
+        if (this.tasks[i].events.length === 0) {
+          this.tasks.splice(i, 1)
+        }
         return true
       }
     }


### PR DESCRIPTION
See [this comment](https://github.com/mostjs/core/issues/266#issuecomment-459485449) for an example of the bug.  It's a subtle interaction between `run` and `until`.

This PR fixes the bug.

Naively fixing the bug introduced a race between disposables.  SettableDisposable is the standard way to break disposable races in a controlled way, and it worked well here.

Looking at `since` and `until` with fresh eyes, it also seemed they could be simplified.  So, I did.  I also made Timeline slightly more aggressive in freeing its internal data structures when it knows it has an empty time slot.

### Todo

- [x] Add a unit test to prevent regression.  This is tricky to test, since it's in a part of the code that is hard to observe from the outside.