### PR TITLE
Fix bug in take-skip bounds optimization

### DIFF
--- a/packages/core/src/combinator/slice/index.js
+++ b/packages/core/src/combinator/slice/index.js
@@ -46,7 +46,7 @@ const commuteMapSlice = (bounds, mapStream) =>
   Map.create(mapStream.f, sliceBounds(bounds, mapStream.source))
 
 const fuseSlice = (bounds, sliceStream) =>
-  sliceBounds(mergeBounds(bounds, sliceStream.bounds), sliceStream.source)
+  sliceBounds(mergeBounds(sliceStream.bounds, bounds), sliceStream.source)
 
 class Slice {
   constructor (bounds, source) {

--- a/packages/core/test/combinator/slice/index-test.js
+++ b/packages/core/test/combinator/slice/index-test.js
@@ -28,12 +28,12 @@ describe('slice', function () {
 
     it('should narrow when second slice is smaller', function () {
       const s = slice(1, 5, slice(1, 10, now('')))
-      eq(boundsFrom(2, 5), s.bounds)
+      eq(boundsFrom(2, 6), s.bounds)
     })
 
     it('should narrow when second slice is larger', function () {
       const s = slice(1, 10, slice(1, 5, now('')))
-      eq(boundsFrom(2, 6), s.bounds)
+      eq(boundsFrom(2, 5), s.bounds)
     })
 
     it('should commute map', function () {
@@ -66,6 +66,16 @@ describe('slice', function () {
     it('given infinite bounds, should be identity', () => {
       const s = makeEvents(1, 3)
       is(s, slice(0, Infinity, s))
+    })
+
+    it('should accumulate take(..., skip(...))', () => {
+      const s = take(1, skip(1, now('')))
+      eq(boundsFrom(1, 2), s.bounds)
+    })
+
+    it('should accumulate skip(..., take(...))', () => {
+      const s = skip(1, take(1, now('')))
+      assert(isCanonicalEmpty(s))
     })
   })
 


### PR DESCRIPTION
Fix #271

This fixes a bug in the slice bounds fusion.  There was also a bug in the unit tests that hid the optimization bug.