### PR TITLE
Add most-redis-docker example.

### DIFF
--- a/examples/most-redis-docker/.gitignore
+++ b/examples/most-redis-docker/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-.DS_Store

--- a/examples/most-redis-docker/.gitignore
+++ b/examples/most-redis-docker/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/examples/most-redis-docker/Dockerfile
+++ b/examples/most-redis-docker/Dockerfile
@@ -1,9 +1,6 @@
 FROM node:10.12.0-jessie
-# https://github.com/Yelp/dumb-init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64
-RUN chmod +x /usr/local/bin/dumb-init
-RUN mkdir -p /app
-WORKDIR /app
-ADD . /app/
+WORKDIR /usr/src/app
+COPY package*.json ./
 RUN npm install
-# CMD ["/usr/local/bin/dumb-init", "npm", "run", "start"]
+COPY . .
+# Entrypoint can vary so it must be provided at startup

--- a/examples/most-redis-docker/Dockerfile
+++ b/examples/most-redis-docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:10.12.0-jessie
+# https://github.com/Yelp/dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64
+RUN chmod +x /usr/local/bin/dumb-init
+RUN mkdir -p /app
+WORKDIR /app
+ADD . /app/
+RUN npm install
+# CMD ["/usr/local/bin/dumb-init", "npm", "run", "start"]

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -27,8 +27,9 @@ if you chose another folder name.
 
 This project uses environment variables.  If you are using the windows command
 prompt, you may have to change some commands slightly to use env vars. For
-example, rather than type `REDIS_MYCHANNEL=my_channel npm run consume`, you
-would type `set REDIS_MYCHANNEL=my_channel&&npm run consume`.
+example, rather than type
+`REDIS_MYCHANNEL=most-redis-docker-example npm run consume`, you would type
+`set REDIS_MYCHANNEL=most-redis-docker-example&&npm run consume`.
 
 ### Option 1: Docker
 
@@ -37,7 +38,7 @@ would type `set REDIS_MYCHANNEL=my_channel&&npm run consume`.
 2.  Build the docker image for this project:
 
 ```sh
-docker build -t most-redis .
+docker build -t most-redis-docker .
 ```
 
 ### Option 2: node.js
@@ -81,19 +82,19 @@ stop the docker-compose network in the background.
 1. From the `most-redis-docker` folder:
 
 ```sh
-REDIS_MYCHANNEL=my_channel npm run consume
+REDIS_MYCHANNEL=most-redis-docker-example npm run consume
 ```
 
 2. Open a new terminal or shell, and from the `most-redis-docker` folder type:
 
 ```sh
-REDIS_MYCHANNEL=my_channel npm run consume
+REDIS_MYCHANNEL=most-redis-docker-example npm run consume
 ```
 
 3. Open a third terminal or shell, and from the `most-redis-docker` folder type:
 
 ```sh
-REDIS_MYCHANNEL=my_channel npm run publish
+REDIS_MYCHANNEL=most-redis-docker-example npm run publish
 ```
 
 ## Experiment!

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -112,7 +112,7 @@ Both the `consume` and `publish` services accept env vars.  If you are using
 Docker, these may be modified in the `docker-compose.yml` file.  The following
 env vars are used:
 
-- `REDIS_CHANNEL`: string, _required_
+- `REDIS_CHANNEL`: string, default is `'most-redis-docker-example'`
 - `REDIS_PORT`: integer, default is `6379`
 - `REDIS_HOST`: string, default is `'127.0.0.1'`
 - `TIMEOUT`: integer, default is `2500`

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -28,8 +28,8 @@ if you chose another folder name.
 This project uses environment variables.  If you are using the windows command
 prompt, you may have to change some commands slightly to use env vars. For
 example, rather than type
-`REDIS_MYCHANNEL=most-redis-docker-example npm run consume`, you would type
-`set REDIS_MYCHANNEL=most-redis-docker-example&&npm run consume`.
+`REDIS_CHANNEL=most-redis-docker-example npm run consume`, you would type
+`set REDIS_CHANNEL=most-redis-docker-example&&npm run consume`.
 
 ### Option 1: Docker
 
@@ -89,19 +89,19 @@ redis-server
 2. From the `most-redis-docker` folder:
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example node consume
+REDIS_CHANNEL=most-redis-docker-example node consume
 ```
 
 3. Open a new terminal or shell, and from the `most-redis-docker` folder type:
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example node consume
+REDIS_CHANNEL=most-redis-docker-example node consume
 ```
 
 4. Open a third terminal or shell, and from the `most-redis-docker` folder type:
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example node publish
+REDIS_CHANNEL=most-redis-docker-example node publish
 ```
 
 ## Experiment!

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -112,9 +112,9 @@ Both the `consume` and `publish` services accept env vars.  If you are using
 Docker, these may be modified in the `docker-compose.yml` file.  The following
 env vars are used:
 
+- `REDIS_CHANNEL`: string, _required_
 - `REDIS_PORT`: integer, default is `6379`
 - `REDIS_HOST`: string, default is `'127.0.0.1'`
-- `REDIS_CHANNEL`: string, required
 - `TIMEOUT`: integer, default is `2500`
 
 ### Try these scenarios

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -111,11 +111,14 @@ env vars are used:
 
 ### Try these scenarios
 
-- Easy: Change the channel name for one or more of the services.
-- Easy: Change the timeout to 0 (there are two ways to do this).  What happens?
-- Master: Handle some messages differently from others.  Hint: try most.js's
+- *Easy*: Change the channel name for one or more of the services.
+- *Easy*: Change the timeout to 0 (there are two ways to do this).  What happens?
+- *Master*: Handle some messages differently from others.  Hint: try most.js's
   `filter`, `skipWhile`, or `takeWhile` in the `consume` service.
-- Guru: Send invalid JSON from the `publish` service and use `recoverWith` in
+- *Master*: Modify and configure the `publish` service to publish to 2 channels,
+  then configure the `consume` services to each listen to one of those channels.
+  Hint: accept a comma-separated list of channels via `REDIS_CHANNEL`?
+- *Guru*: Send invalid JSON from the `publish` service and use `recoverWith` in
   the `consume` service to handle it.
-- Guru: Create a _selective forwarding_ service by re-publishing _some_ of the
+- *Guru*: Create a _selective forwarding_ service by re-publishing _some_ of the
   messages from the `consume` service.  

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -1,0 +1,121 @@
+# Most + Redis + Docker
+
+A suite of simple apps to illustrate how to use most to handle redis events.
+
+This suite may be run using [docker](https://www.docker.com) or [node.js
+10.x](https://nodejs.org/en/).  If you have docker installed already or would
+like to try it, follow the docker instructions.  Otherwise, you will need to be
+running redis locally.  Follow the node instructions to install node and redis.
+
+## Install
+
+### Pre-requisites
+
+1. Install [git](https://help.github.com/articles/set-up-git/)
+2. Clone this repo:
+
+```sh
+git clone git@github.com:mostjs/core.git
+cd examples/most-redis-docker
+```
+
+### Assumptions
+
+The remainder of this document assumes your working directory is
+`most-redis-docker`.  You may have to modify some of the following directions
+if you chose another folder name.
+
+This project uses environment variables.  If you are using the windows command
+prompt, you may have to change some commands slightly to use env vars. For
+example, rather than type `REDIS_MYCHANNEL=my_channel npm run consume`, you
+would type `set REDIS_MYCHANNEL=my_channel&&npm run consume`.
+
+### Option 1: Docker
+
+1.  Install [docker](https://www.docker.com/get-started).  (You will need to
+    create a [DockerHub](https://hub.docker.com) account.)
+2.  Build the docker image for this project:
+
+```sh
+docker build -t most-redis .
+```
+
+### Option 2: node.js
+
+1. Install [node 10.x](https://nodejs.org/en/) or the latest LTS version.
+2. Install the dependencies for this project:
+
+```sh
+npm install
+```
+
+3. Install [redis](https://redis.io/topics/quickstart).
+
+If you already have an instance of redis running, you may edit the docker-
+compose.yml file in the `most-redis-docker` folder.  Change any values for
+`REDIS_HOST` and `REDIS_PORT` according to your redis instance
+
+## Run
+
+When running this example, the publish service periodically sends JSON messages
+to redis, and the consume services receive the JSON messages and transform
+them.  In your terminal(s), you should expect to see informational logs from
+each service as they start up and as they process the JSON messages.
+
+### Option 1: Docker
+
+1.  From the `most-redis-docker` folder, create and run the docker-compose
+    network defined in `docker-compose.yml`:
+
+```sh
+docker-compose up
+```
+
+Use `Ctrl-C` to stop the docker-compose network.
+
+You may also use `docker-compose up -d` and `docker-compose down` to start and
+stop the docker-compose network in the background.
+
+### Option 2: node.js
+
+1. From the `most-redis-docker` folder:
+
+```sh
+REDIS_MYCHANNEL=my_channel npm run consume
+```
+
+2. Open a new terminal or shell, and from the `most-redis-docker` folder type:
+
+```sh
+REDIS_MYCHANNEL=my_channel npm run consume
+```
+
+3. Open a third terminal or shell, and from the `most-redis-docker` folder type:
+
+```sh
+REDIS_MYCHANNEL=my_channel npm run publish
+```
+
+## Experiment!
+
+### Env vars
+
+Both the `consume` and `publish` services accept env vars.  If you are using
+Docker, these may be modified in the `docker-compose.yml` file.  The following
+env vars are used:
+
+- `REDIS_PORT`: integer, default is `6379`
+- `REDIS_HOST`: string, default is `'127.0.0.1'`
+- `REDIS_CHANNEL`: string, required
+- `TIMEOUT`: integer, default is `2500`
+
+### Try these scenarios
+
+- Easy: Change the channel name for one or more of the services.
+- Easy: Change the timeout to 0 (there are two ways to do this).  What happens?
+- Master: Handle some messages differently from others.  Hint: try most.js's
+  `filter`, `skipWhile`, or `takeWhile` in the `consume` service.
+- Guru: Send invalid JSON from the `publish` service and use `recoverWith` in
+  the `consume` service to handle it.
+- Guru: Create a _selective forwarding_ service by re-publishing _some_ of the
+  messages from the `consume` service.  

--- a/examples/most-redis-docker/README.md
+++ b/examples/most-redis-docker/README.md
@@ -79,22 +79,29 @@ stop the docker-compose network in the background.
 
 ### Option 2: node.js
 
-1. From the `most-redis-docker` folder:
+1.  Start redis.  See the [redis docs](https://redis.io/topics/quickstart) for
+    troubleshooting and options.
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example npm run consume
+redis-server
 ```
 
-2. Open a new terminal or shell, and from the `most-redis-docker` folder type:
+2. From the `most-redis-docker` folder:
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example npm run consume
+REDIS_MYCHANNEL=most-redis-docker-example node consume
 ```
 
-3. Open a third terminal or shell, and from the `most-redis-docker` folder type:
+3. Open a new terminal or shell, and from the `most-redis-docker` folder type:
 
 ```sh
-REDIS_MYCHANNEL=most-redis-docker-example npm run publish
+REDIS_MYCHANNEL=most-redis-docker-example node consume
+```
+
+4. Open a third terminal or shell, and from the `most-redis-docker` folder type:
+
+```sh
+REDIS_MYCHANNEL=most-redis-docker-example node publish
 ```
 
 ## Experiment!

--- a/examples/most-redis-docker/config.js
+++ b/examples/most-redis-docker/config.js
@@ -1,0 +1,14 @@
+// Functions to handle app configuration.
+
+const config
+  = exports.config
+  = env => {
+    const port = Number(env.REDIS_PORT || 6379)
+    const host = String(env.REDIS_HOST || '127.0.0.1')
+    const timeout = Number(env.TIMEOUT || 2500)
+    const channel = env.REDIS_CHANNEL
+
+    if (!channel) throw new Error(`REDIS_CHANNEL not specified.`)
+
+    return { port, host, timeout, channel }
+  }

--- a/examples/most-redis-docker/config.js
+++ b/examples/most-redis-docker/config.js
@@ -6,7 +6,8 @@ const config
     const port = 'REDIS_PORT' in env ? Number(env.REDIS_PORT) : 6379
     const host = 'REDIS_HOST' in env ? env.REDIS_HOST : '127.0.0.1'
     const timeout = 'TIMEOUT' in env ? Number(env.TIMEOUT) : 2500
-    const channel = 'REDIS_CHANNEL' in env ? env.REDIS_CHANNEL : 'my_channel'
+    const channel
+      = 'REDIS_CHANNEL' in env ? env.REDIS_CHANNEL : 'most-redis-docker-example'
 
     // The other env vars will cause obvious errors if missing, but
     // `REDIS_CHANNEL` will cause silent failures if the user forgets to set it.

--- a/examples/most-redis-docker/config.js
+++ b/examples/most-redis-docker/config.js
@@ -2,13 +2,16 @@
 
 const config
   = exports.config
-  = env => {
-    const port = Number(env.REDIS_PORT || 6379)
-    const host = String(env.REDIS_HOST || '127.0.0.1')
-    const timeout = Number(env.TIMEOUT || 2500)
-    const channel = env.REDIS_CHANNEL
+  = report => env => {
+    const port = 'REDIS_PORT' in env ? Number(env.REDIS_PORT) : 6379
+    const host = 'REDIS_HOST' in env ? env.REDIS_HOST : '127.0.0.1'
+    const timeout = 'TIMEOUT' in env ? Number(env.TIMEOUT) : 2500
+    const channel = 'REDIS_CHANNEL' in env ? env.REDIS_CHANNEL : 'my_channel'
 
-    if (!channel) throw new Error(`REDIS_CHANNEL not specified.`)
+    // The other env vars will cause obvious errors if missing, but
+    // `REDIS_CHANNEL` will cause silent failures if the user forgets to set it.
+    if (!('REDIS_CHANNEL' in env))
+      report(`Warning: REDIS_CHANNEL env var is missing. Using ${channel}.`)
 
     return { port, host, timeout, channel }
   }

--- a/examples/most-redis-docker/consume.js
+++ b/examples/most-redis-docker/consume.js
@@ -22,18 +22,22 @@ const client
 // Create an adapter to "push" events from redis.
 const [ onMessage, messageStream ] = createAdapter()
 
-// Create a most.js stream
+// Create the operations on a simple most.js stream that:
+// - parses a JSON message and extracts the `value` property,
+// - logs the value as a side effect,
 const fromMessage
   = map(message => JSON.parse(message).value)
 const logValue
   = tap(value => log('received value =', value))
 
+// Compose the stream from the operations.
 const receiveNewValues
   = fromMessage(logValue(messageStream))
 
-// TODO: transform or something?
+// Run the stream.
 runEffects(receiveNewValues, newDefaultScheduler())
 
+// Start the app.
 client
   .then(subscribe(channel, onMessage))
   .then(() => log(`Consumer listening on ${channel}.`))

--- a/examples/most-redis-docker/consume.js
+++ b/examples/most-redis-docker/consume.js
@@ -1,0 +1,40 @@
+// Composition plan to consume a redis stream
+
+const redis = require('redis')
+const { init: initRedisClient, subscribe } = require('./redis')
+const { runEffects, map, tap } = require("@most/core")
+const { createAdapter } = require("@most/adapter")
+const { newDefaultScheduler } = require("@most/scheduler")
+const { config } = require('./config')
+
+// Create a logging abstraction.  Could also be graylog, logstash, etc.
+const { log, error } = console
+const crash = err => { error(err); process.exit(1) }
+
+// Read config from env vars.
+const { host, port, timeout, channel } = config(process.env)
+
+// Create and initialize a redis client.
+const client
+  = initRedisClient(redis, { host, port, timeout }, error)
+    .catch(crash) // fail hard if we can't connect!
+
+// Create an adapter to "push" events from redis.
+const [ onMessage, messageStream ] = createAdapter()
+
+// Create a most.js stream
+const fromMessage
+  = map(message => JSON.parse(message).value)
+const logValue
+  = tap(value => log('received value =', value))
+
+const receiveNewValues
+  = fromMessage(logValue(messageStream))
+
+// TODO: transform or something?
+runEffects(receiveNewValues, newDefaultScheduler())
+
+client
+  .then(subscribe(channel, onMessage))
+  .then(() => log(`Consumer listening on ${channel}.`))
+  .catch(crash)

--- a/examples/most-redis-docker/consume.js
+++ b/examples/most-redis-docker/consume.js
@@ -8,11 +8,11 @@ const { newDefaultScheduler } = require("@most/scheduler")
 const { config } = require('./config')
 
 // Create a logging abstraction.  Could also be graylog, logstash, etc.
-const { log, error } = console
+const { log, error, warn } = console
 const crash = err => { error(err); process.exit(1) }
 
 // Read config from env vars.
-const { host, port, timeout, channel } = config(process.env)
+const { host, port, timeout, channel } = config(warn)(process.env)
 
 // Create and initialize a redis client.
 const client

--- a/examples/most-redis-docker/docker-compose.yml
+++ b/examples/most-redis-docker/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.2'
+networks:
+  default: null
+services:
+  redis:
+    image: redis:5.0
+    ports:
+      - 6379:6379
+  consumer1:
+    image: most-redis
+    entrypoint:
+      - node
+      - consume
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_CHANNEL: my_channel
+    volumes:
+      - $PWD:/app
+    depends_on:
+      - redis
+  consumer2:
+    image: most-redis
+    entrypoint:
+      - node
+      - consume
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_CHANNEL: my_channel
+    volumes:
+      - $PWD:/app
+    depends_on:
+      - redis
+  publisher:
+    image: most-redis
+    entrypoint:
+      - node
+      - publish
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_CHANNEL: my_channel
+    volumes:
+      - $PWD:/app
+    depends_on:
+      - redis

--- a/examples/most-redis-docker/docker-compose.yml
+++ b/examples/most-redis-docker/docker-compose.yml
@@ -7,40 +7,40 @@ services:
     ports:
       - 6379:6379
   consumer1:
-    image: most-redis
+    image: most-redis-docker
     entrypoint:
       - node
       - consume
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      REDIS_CHANNEL: my_channel
+      REDIS_CHANNEL: most-redis-docker-example
     volumes:
       - $PWD:/app
     depends_on:
       - redis
   consumer2:
-    image: most-redis
+    image: most-redis-docker
     entrypoint:
       - node
       - consume
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      REDIS_CHANNEL: my_channel
+      REDIS_CHANNEL: most-redis-docker-example
     volumes:
       - $PWD:/app
     depends_on:
       - redis
   publisher:
-    image: most-redis
+    image: most-redis-docker
     entrypoint:
       - node
       - publish
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      REDIS_CHANNEL: my_channel
+      REDIS_CHANNEL: most-redis-docker-example
     volumes:
       - $PWD:/app
     depends_on:

--- a/examples/most-redis-docker/package-lock.json
+++ b/examples/most-redis-docker/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "most-redis",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@most/adapter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@most/adapter/-/adapter-1.0.0.tgz",
+      "integrity": "sha512-+ECkLCTgKqc+uFK7q/fp2elaZahNRS1Tjz0XAu5QOiMynxJt8qN8LR+fuSoRZdhzQ0/+4nWf44X/x2fWUKe8fQ==",
+      "requires": {
+        "@most/types": "^1.0.1"
+      }
+    },
+    "@most/core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@most/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-oI2sjIJgyluzf7xWuGMl8qPo/gAAMtArEOLcIiML0QWetOySpgX8OMikrLjsy+K6x+gZm5rOpsITbLTbJo5Z9Q==",
+      "requires": {
+        "@most/disposable": "^1.2.1",
+        "@most/prelude": "^1.7.2",
+        "@most/scheduler": "^1.2.1",
+        "@most/types": "^1.0.1"
+      }
+    },
+    "@most/disposable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@most/disposable/-/disposable-1.2.1.tgz",
+      "integrity": "sha512-VQ5gGZd5VFqYyP3sfYmVbrb4MX7j7tqIQKpoATOz5loDXE/9Y/BU5SzD2pGhVtui62kUdK13UFSom4njtmQ1Lw==",
+      "requires": {
+        "@most/prelude": "^1.7.2",
+        "@most/types": "^1.0.1"
+      }
+    },
+    "@most/prelude": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@most/prelude/-/prelude-1.7.2.tgz",
+      "integrity": "sha512-GM5ec7+xpkuXiCMyzhyENgH/xZ8t0nAMDBY0QOsVVD6TrZYjJKUnW1eaI18HHX8W+COWMwWR9c0zoPiBp9+tUg=="
+    },
+    "@most/scheduler": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@most/scheduler/-/scheduler-1.2.2.tgz",
+      "integrity": "sha512-TcbdJMso8MBX9NO4/5LTitsp1qTKIWMHBXL3aaEqHsCSvHgJNwNOCEG9PrFrBhIoTkVgHVghP8KaoEVqqhxmmg==",
+      "requires": {
+        "@most/prelude": "^1.7.2",
+        "@most/types": "^1.0.1"
+      }
+    },
+    "@most/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@most/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-fCLkp1Yzp+Kamr00i1yG3GPhekOE150TSeoqUAy1cslmJ/a0+x7Y6GCwO26ke614sUbV9BdL0gTGCZJA4V1JUw=="
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.4.0.tgz",
+      "integrity": "sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    }
+  }
+}

--- a/examples/most-redis-docker/package-lock.json
+++ b/examples/most-redis-docker/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "most-redis",
+  "name": "most-redis-docker",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/examples/most-redis-docker/package.json
+++ b/examples/most-redis-docker/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "most-redis-docker",
+  "version": "1.0.0",
+  "description": "Coordinate redis events with most.js",
+  "scripts": {
+    "publisher": "node publish",
+    "consumer": "node consume"
+  },
+  "author": "@unscriptable",
+  "license": "MIT",
+  "dependencies": {
+    "@most/adapter": "^1.0.0",
+    "@most/core": "^1.3.2",
+    "@most/scheduler": "^1.2.2",
+    "redis": "^2.8.0"
+  },
+  "keywords": [
+    "most",
+    "redis",
+    "event",
+    "stream",
+    "docker"
+  ]
+}

--- a/examples/most-redis-docker/publish.js
+++ b/examples/most-redis-docker/publish.js
@@ -7,11 +7,11 @@ const { newDefaultScheduler } = require("@most/scheduler")
 const { config } = require('./config')
 
 // Create a logging abstraction.  Could also be graylog, logstash, etc.
-const { log, error } = console
+const { log, error, warn } = console
 const crash = err => { error(err); process.exit(1) }
 
 // Read config from env vars.
-const { host, port, timeout, channel } = config(process.env)
+const { host, port, timeout, channel } = config(warn)(process.env)
 
 // Create and initialize a redis client.
 const client

--- a/examples/most-redis-docker/publish.js
+++ b/examples/most-redis-docker/publish.js
@@ -1,0 +1,39 @@
+// Composition plan to publish to a redis stream
+
+const redis = require('redis')
+const { init: initRedisClient, publisher } = require('./redis')
+const { runEffects, periodic, scan, map, tap } = require("@most/core")
+const { newDefaultScheduler } = require("@most/scheduler")
+const { config } = require('./config')
+
+// Create a logging abstraction.  Could also be graylog, logstash, etc.
+const { log, error } = console
+const crash = err => { error(err); process.exit(1) }
+
+// Read config from env vars.
+const { host, port, timeout, channel } = config(process.env)
+
+// Create and initialize a redis client.
+const client
+  = initRedisClient(redis, { host, port, timeout }, error)
+    .catch(crash) // fail hard if we can't connect!
+
+// Create stream
+const everyThreeSeconds
+  = periodic(3000)
+const monotonicallyIncrease
+  = scan(b => b + 1)
+const toJsonMessage
+  = map(value => JSON.stringify({ value }))
+const logValue
+  = tap(value => log('sending value =', value))
+
+const emitPeriodicMonotonicNumbers
+  = logValue(toJsonMessage(monotonicallyIncrease(0)(everyThreeSeconds)))
+
+client
+  .then(publisher(channel))
+  .then(publish => tap(publish, emitPeriodicMonotonicNumbers))
+  .then(stream => runEffects(stream, newDefaultScheduler()))
+  .then(() => log(`Publisher publishing on ${channel}.`))
+  .catch(crash)

--- a/examples/most-redis-docker/publish.js
+++ b/examples/most-redis-docker/publish.js
@@ -18,7 +18,11 @@ const client
   = initRedisClient(redis, { host, port, timeout }, error)
     .catch(crash) // fail hard if we can't connect!
 
-// Create stream
+// Create the operations on a simple most.js stream that:
+// - creates a new event every 3 seconds,
+// - increments ("monotonically increases") a value,
+// - stringifies to a JSON object with a `value` property,
+// - logs the value as a side effect.
 const everyThreeSeconds
   = periodic(3000)
 const monotonicallyIncrease
@@ -28,9 +32,14 @@ const toJsonMessage
 const logValue
   = tap(value => log('sending value =', value))
 
+// Compose the stream from the operations.
 const emitPeriodicMonotonicNumbers
   = logValue(toJsonMessage(monotonicallyIncrease(0)(everyThreeSeconds)))
 
+// Start the app.
+// Note how the `publish` function is composed into the stream as a side effect.`
+// This happens in a promise chain because the redis client and, therefore, the
+// `publish` function are available asynchronously.
 client
   .then(publisher(channel))
   .then(publish => tap(publish, emitPeriodicMonotonicNumbers))

--- a/examples/most-redis-docker/redis.js
+++ b/examples/most-redis-docker/redis.js
@@ -1,0 +1,50 @@
+// Functions to work with redis clients.
+
+// Create and initialize a redis client using the proided host, port, timeout,
+// and onError handler.
+const init
+  = exports.init
+  = ({ createClient }, { port, host, timeout }, onError) => {
+    // Create a promise for a redis client
+    const clientP
+      = new Promise(
+        (resolve, reject) => {
+          const client = createClient({ port, host })
+          client.on('ready', () => resolve(client))
+          client.on('error', reject)
+        }
+      )
+
+    // Create redis timeout detector (() => Promise)
+    const redisTimeout
+      = rejectAfter(timeout, `Redis failed to respond after ${timeout} msec!`)
+
+    return Promise.race([ clientP, redisTimeout() ])
+      .then(client => client.on('error', onError))
+  }
+
+// Subscribe a client to a channel by name (string), sending received mesasges
+// to the onMessage handler.
+const subscribe
+  = exports.subscribe
+  = (channel, onMessage) => client => {
+    client.on('message', (_, message) => onMessage(message))
+    client.subscribe(channel)
+    return client
+  }
+
+// Create a publish function for a redis client that sends messages on a
+// sepcific channel by name (string).
+const publisher
+  = exports.publisher
+  = channel => client => {
+    return message => client.publish(channel, message)
+  }
+
+// Helper: reject after the given msec with an Error having the given message.
+const rejectAfter
+  = (msec, message) => () =>
+    new Promise(
+      (_, reject) =>
+        setTimeout(() => reject(new Error(message)), msec)
+    )


### PR DESCRIPTION
I think it's hard to provide an example that is easy to run and is also somewhat close to a "real world" scenario.  By allowing users to run this example by installing docker _or_ installing redis, I hope to make it a bit easier.  

I'm very open to suggestions and improvements:  coding style, README contents, variable names, etc.  

Honestly, composing the most.js streams felt clunky without formal function composition tools.  Am I doing it right?  Could I do it better?
