### PR TITLE
Apply new technique for strong heterogenous array types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -660,7 +660,7 @@ mergeArray
 
 .. code-block:: haskell
 
-  mergeArray :: [ (Stream a) ] -> Stream a
+  mergeArray :: [ Stream a, Stream b, ... ] -> Stream (a | b | ...)
 
 Array form of :ref:`merge`. Create a new :ref:`Stream` containing all events from all :ref:`Streams <Stream>` in the array. ::
 

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -76,7 +76,7 @@ declare export function switchLatest <A> (s: Stream<Stream<A>>): Stream<A>
 declare export function merge <A, B> (s1: Stream<A>, s2: Stream<B>): Stream<A | B>
 declare export function merge <A, B> (s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
 
-type MergeArray = <A>(Array<Stream<A>>) => Stream<A>
+type MergeArray = <A>($ReadOnlyArray<Stream<A>>) => Stream<A>
 declare export function mergeArray <S> (ss: S): $Call<MergeArray, S>
 
 declare export function sample <A> (values: Stream<A>, sampler: Stream<any>): Stream<A>

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -75,7 +75,9 @@ declare export function switchLatest <A> (s: Stream<Stream<A>>): Stream<A>
 
 declare export function merge <A, B> (s1: Stream<A>, s2: Stream<B>): Stream<A | B>
 declare export function merge <A, B> (s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
-declare export function mergeArray <A> (ss: Array<Stream<A>>): Stream<A>
+
+type MergeArray = <A>(Array<Stream<A>>) => Stream<A>
+declare export function mergeArray <S> (ss: S): $Call<MergeArray, S>
 
 declare export function sample <A> (values: Stream<A>, sampler: Stream<any>): Stream<A>
 declare export function sample <A> (values: Stream<A>): (sampler: Stream<any>) => Stream<A>

--- a/packages/core/test/flow/combinator/mergeArray.js
+++ b/packages/core/test/flow/combinator/mergeArray.js
@@ -1,0 +1,8 @@
+// @flow
+import { mergeArray, now, runEffects } from '../../../src/index'
+import { type Stream } from '@most/types'
+import { newDefaultScheduler } from '@most/scheduler'
+
+const s: Stream<number | string | boolean> = mergeArray([now(123), now('a'), now(true)])
+
+runEffects(s, newDefaultScheduler())

--- a/packages/core/type-definitions/combinator/combine.d.ts
+++ b/packages/core/type-definitions/combinator/combine.d.ts
@@ -1,14 +1,10 @@
 import { Stream } from '@most/types';
+import { ToStreamsArray } from './variadic'
 
 export function combine<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>, b: Stream<B>): Stream<R>;
 export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Stream<B>) => Stream<R>;
 export function combine<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
-
-// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
-type ToStreamsArray<A extends ReadonlyArray<any>> = {
-  [K in keyof A]: Stream<A[K]>
-}
 
 export function combineArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>;
 export function combineArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>;

--- a/packages/core/type-definitions/combinator/combine.d.ts
+++ b/packages/core/type-definitions/combinator/combine.d.ts
@@ -5,6 +5,7 @@ export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Strea
 export function combine<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
 
+// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
 type ToStreamsArray<A extends ReadonlyArray<any>> = {
   [K in keyof A]: Stream<A[K]>
 }

--- a/packages/core/type-definitions/combinator/combine.d.ts
+++ b/packages/core/type-definitions/combinator/combine.d.ts
@@ -5,39 +5,9 @@ export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Strea
 export function combine<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function combine<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
 
-export function combineArray<A, B, R>(
-  fn: (a: A, b: B) => R,
-  streams: [Stream<A>, Stream<B>]
-): Stream<R>;
-export function combineArray<A, B, C, R>(
-  fn: (a: A, b: B, c: C) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>]
-): Stream<R>;
-export function combineArray<A, B, C, D, R>(
-  fn: (a: A, b: B, c: C, d: D) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>]
-): Stream<R>;
-export function combineArray<A, B, C, D, E, R>(
-  fn: (a: A, b: B, c: C, d: D, e: E) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>, Stream<E>]
-): Stream<R>;
-export function combineArray<V, R> (
-  fn: (...items: V[]) => R,
-  items: Stream<V>[]
-): Stream<R>;
+type ToStreamsArray<A extends ReadonlyArray<any>> = {
+  [K in keyof A]: Stream<A[K]>
+}
 
-export function combineArray<A, B, R>(
-  fn: (a: A, b: B) => R,):
-  (streams: [Stream<A>, Stream<B>]) => Stream<R>;
-export function combineArray<A, B, C, R>(
-  fn: (a: A, b: B, c: C) => R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>]) => Stream<R>;
-export function combineArray<A, B, C, D, R>(
-  fn: (a: A, b: B, c: C, d: D) => R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>]) => Stream<R>;
-export function combineArray<A, B, C, D, E, R>(
-  fn: (a: A, b: B, c: C, d: D, e: E) => R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>, Stream<E>]) => Stream<R>;
-export function combineArray<V, R> (
-  fn: (...items: V[]) => R):
-  (items: Stream<V>[]) => Stream<R>;
+export function combineArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>;
+export function combineArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>;

--- a/packages/core/type-definitions/combinator/merge.d.ts
+++ b/packages/core/type-definitions/combinator/merge.d.ts
@@ -3,6 +3,7 @@ import { Stream } from '@most/types';
 export function merge<A, B>(s1: Stream<A>, s2: Stream<B>): Stream<A | B>;
 export function merge<A, B>(s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
 
+// TODO: use readonly Stream<any>[] once TS 3.4.x has been in the wild for "enough" time
 type MergeArray<S extends ReadonlyArray<Stream<any>>> = Value<S[number]>
 type Value<S> = S extends Stream<infer A> ? A : never
 

--- a/packages/core/type-definitions/combinator/merge.d.ts
+++ b/packages/core/type-definitions/combinator/merge.d.ts
@@ -2,4 +2,8 @@ import { Stream } from '@most/types';
 
 export function merge<A, B>(s1: Stream<A>, s2: Stream<B>): Stream<A | B>;
 export function merge<A, B>(s1: Stream<A>): (s2: Stream<B>) => Stream<A | B>
-export function mergeArray<A>(streams: Array<Stream<A>>): Stream<A>;
+
+type MergeArray<S extends ReadonlyArray<Stream<any>>> = Value<S[number]>
+type Value<S> = S extends Stream<infer A> ? A : never
+
+export function mergeArray<S extends ReadonlyArray<Stream<any>>>(streams: S): Stream<MergeArray<S>>;

--- a/packages/core/type-definitions/combinator/variadic.d.ts
+++ b/packages/core/type-definitions/combinator/variadic.d.ts
@@ -1,0 +1,7 @@
+// Map arrays to arrays of Streams:
+// Array<A> => Array<Stream<A>>
+// [A, B, C, ...] => [Stream<A>, Stream<B>, Stream<C>, ...]
+// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
+export type ToStreamsArray<A extends ReadonlyArray<any>> = {
+  [K in keyof A]: Stream<A[K]>
+}

--- a/packages/core/type-definitions/combinator/zip.d.ts
+++ b/packages/core/type-definitions/combinator/zip.d.ts
@@ -5,9 +5,10 @@ export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Stream<B>
 export function zip<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
 
-type ToStreams<A extends ReadonlyArray<any>> = {
+// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
+type ToStreamsArray<A extends ReadonlyArray<any>> = {
   [K in keyof A]: Stream<A[K]>
 }
 
-export function zipArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreams<Args>): Stream<R>;
-export function zipArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreams<Args>) => Stream<R>;
+export function zipArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>;
+export function zipArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>;

--- a/packages/core/type-definitions/combinator/zip.d.ts
+++ b/packages/core/type-definitions/combinator/zip.d.ts
@@ -1,14 +1,10 @@
 import { Stream } from '@most/types';
+import { ToStreamsArray } from './variadic'
 
 export function zip<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>, b: Stream<B>): Stream<R>;
 export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Stream<B>) => Stream<R>;
 export function zip<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
-
-// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
-type ToStreamsArray<A extends ReadonlyArray<any>> = {
-  [K in keyof A]: Stream<A[K]>
-}
 
 export function zipArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>;
 export function zipArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>;

--- a/packages/core/type-definitions/combinator/zip.d.ts
+++ b/packages/core/type-definitions/combinator/zip.d.ts
@@ -5,38 +5,9 @@ export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>, b: Stream<B>
 export function zip<A, B, R>(fn: (a: A, b: B) => R, a: Stream<A>): (b: Stream<B>) => Stream<R>;
 export function zip<A, B, R>(fn: (a: A, b: B) => R): (a: Stream<A>) => (b: Stream<B>) => Stream<R>;
 
-export function zipArray<A, B, R>(
-  fn: (a: A, b: B) => R,
-  streams: [Stream<A>, Stream<B>]
-): Stream<R>;
-export function zipArray<A, B, C, R>(
-  fn: (a: A, b: B, c: C) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>]
-): Stream<R>;
-export function zipArray<A, B, C, D, R>(
-  fn: (a: A, b: B, c: C, d: D) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>]
-): Stream<R>;
-export function zipArray<A, B, C, D, E, R>(
-  fn: (a: A, b: B, c: C, d: D, e: E) => R,
-  streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>, Stream<E>]
-): Stream<R>;
-export function zipArray<V, R> (
-  fn: (...items: V[]) => R,
-  items: Stream<V>[]
-): Stream<R>;
+type ToStreams<A extends ReadonlyArray<any>> = {
+  [K in keyof A]: Stream<A[K]>
+}
 
-export function zipArray<A, B, R>(fn: (a: A, b: B) => R):
-  (streams: [Stream<A>, Stream<B>]) => Stream<R>;
-
-export function zipArray<A, B, C, R>(fn: (a: A, b: B, c: C)=> R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>]) => Stream<R>;
-
-export function zipArray<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>]) => Stream<R>;
-
-export function zipArray<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R):
-  (streams: [Stream<A>, Stream<B>, Stream<C>, Stream<D>, Stream<E>]) => Stream<R>;
-
-export function zipArray<V, R> (fn: (...items: V[]) => R):
-  (items: Stream<V>[]) => Stream<R>;
+export function zipArray<Args extends any[], R>(fn: (...args: Args) => R, streams: ToStreams<Args>): Stream<R>;
+export function zipArray<Args extends any[], R>(fn: (...args: Args) => R): (streams: ToStreams<Args>) => Stream<R>;


### PR DESCRIPTION
This uses a variation of the technique from [Simpler Variadic Function Types in Typescript](https://gist.github.com/briancavalier/62f784e20e4fffc4d671126b7f91bad0) to improve the types of zipArray and combineArray for TS, allowing them to scale to any arity.

It also improves the type of mergeArray, allowing it to be heterogeneous while remaining strongly typed.  Essentially, this extends the union behavior of `merge` to arbitrary arrays of streams.  This works by leveraging the fact that TS union types obey a distributive law.

### Potential Gotchas

In general, I see strong heterogeneous types as a plus.  However, there could be a couple downsides:

1. They could be surprising or confusing for some users.
2. I haven't found any way to achieve parity in Flow.  What are the implications for documentation?

### Todos

- [x] `ToStreamsArray` is duplicated, consider extracting it somewhere
- [x] Figure out the implications for docs, given that Flow can't handle this (afaict)