### PR TITLE
Fix duplicate addition of offset time on switchLatest

### DIFF
--- a/packages/core/src/combinator/switch.js
+++ b/packages/core/src/combinator/switch.js
@@ -110,6 +110,6 @@ class Segment {
   }
 
   _dispose (t) {
-    tryDispose(t + this.min, this.disposable, this.sink)
+    tryDispose(t, this.disposable, this.sink)
   }
 }

--- a/packages/core/test/switch-test.js
+++ b/packages/core/test/switch-test.js
@@ -11,7 +11,7 @@ import { ticks, collectEventsFor, makeEvents, makeEventsFromArray } from './help
 import { runEffects } from '../src/runEffects'
 
 describe('switch', () => {
-  it('given c anonical empty string, should return canonical empty', () => {
+  it('given canonical empty string, should return canonical empty', () => {
     const s = switchLatest(empty())
     assert(isCanonicalEmpty(s))
   })

--- a/packages/core/test/switch-test.js
+++ b/packages/core/test/switch-test.js
@@ -1,6 +1,5 @@
 import { describe, it } from 'mocha'
 import { assert, eq, fail } from '@briancavalier/assert'
-import { disposeBoth } from '@most/disposable';
 
 import { switchLatest } from '../src/combinator/switch'
 import { take } from '../src/combinator/slice'
@@ -10,8 +9,9 @@ import { empty, isCanonicalEmpty } from '../src/source/empty'
 import { at } from '../src/source/at'
 import { now } from '../src/source/now'
 import { ticks, collectEventsFor, makeEvents, makeEventsFromArray } from './helper/testEnv'
+import FakeDisposeStream from './helper/FakeDisposeStream'
 import { runEffects } from '../src/runEffects'
-import Pipe from '../src/sink/Pipe'
+import { run } from '../src/run'
 
 describe('switch', () => {
   it('given canonical empty string, should return canonical empty', () => {
@@ -91,59 +91,25 @@ describe('switch', () => {
   })
 
   describe('when upper stream fails to dispose', () => {
-    it('should emit an error event with correct time', () => {
-      // This case is a failing test for:
-      // https://github.com/mostjs/core/issues/284
+    it('should emit an error event with correct time', (done) => {
+      // See https://github.com/mostjs/core/issues/284
 
-      let errorEventTime = -1;
-
-      class DisposeFailureStream {
-        constructor (source) {
-          this.source = source
-        }
-
-        run (sink, scheduler) {
-          const disposeFailureSink = new DisposeFailureSink(sink)
-          return disposeBoth(
-            disposeFailureSink,
-            this.source.run(disposeFailureSink, scheduler),
-          )
-        }
-      }
-
-      class DisposeFailureSink extends Pipe {
-        dispose () {
-          throw new Error()
-        }
-      }
-
-      const disposeFailure = s => new DisposeFailureStream(s)
-
-      class AssertErrorTimeStream {
-        constructor (source) {
-          this.source = source
-        }
-
-        run (sink, scheduler) {
-          return this.source.run(new AssertErrorTimeSink(sink), scheduler)
-        }
-      }
-
-      class AssertErrorTimeSink extends Pipe {
+      const inner = FakeDisposeStream.from(() => { throw new Error() }, at(1))
+      const s = at(1, inner)
+      const sink = {
+        event () {},
+        end (t) {},
         error (t, e) {
-          super.error(t, e)
-          errorEventTime = t
+          try {
+            eq(2, t)
+            done()
+          } catch (e) {
+            done(e)
+          }
         }
       }
 
-      const assertErrorTime = s => new AssertErrorTimeStream(s)
-
-      const s = assertErrorTime(switchLatest(at(1, disposeFailure(now(undefined)))))
-      return runEffects(s, ticks(2)).then(() => {
-        fail()
-      }, () => {
-        eq(1, errorEventTime)
-      })
-    });
-  });
+      run(sink, ticks(2), switchLatest(s))
+    })
+  })
 })

--- a/packages/core/test/switch-test.js
+++ b/packages/core/test/switch-test.js
@@ -1,14 +1,17 @@
 import { describe, it } from 'mocha'
 import { assert, eq, fail } from '@briancavalier/assert'
+import { disposeBoth } from '@most/disposable';
 
 import { switchLatest } from '../src/combinator/switch'
 import { take } from '../src/combinator/slice'
 import { constant, map, tap } from '../src/combinator/transform'
 import { periodic } from '../src/source/periodic'
 import { empty, isCanonicalEmpty } from '../src/source/empty'
+import { at } from '../src/source/at'
 import { now } from '../src/source/now'
 import { ticks, collectEventsFor, makeEvents, makeEventsFromArray } from './helper/testEnv'
 import { runEffects } from '../src/runEffects'
+import Pipe from '../src/sink/Pipe'
 
 describe('switch', () => {
   it('given canonical empty string, should return canonical empty', () => {
@@ -86,4 +89,61 @@ describe('switch', () => {
         ]))
     })
   })
+
+  describe('when upper stream fails to dispose', () => {
+    it('should emit an error event with correct time', () => {
+      // This case is a failing test for:
+      // https://github.com/mostjs/core/issues/284
+
+      let errorEventTime = -1;
+
+      class DisposeFailureStream {
+        constructor (source) {
+          this.source = source
+        }
+
+        run (sink, scheduler) {
+          const disposeFailureSink = new DisposeFailureSink(sink)
+          return disposeBoth(
+            disposeFailureSink,
+            this.source.run(disposeFailureSink, scheduler),
+          )
+        }
+      }
+
+      class DisposeFailureSink extends Pipe {
+        dispose () {
+          throw new Error()
+        }
+      }
+
+      const disposeFailure = s => new DisposeFailureStream(s)
+
+      class AssertErrorTimeStream {
+        constructor (source) {
+          this.source = source
+        }
+
+        run (sink, scheduler) {
+          return this.source.run(new AssertErrorTimeSink(sink), scheduler)
+        }
+      }
+
+      class AssertErrorTimeSink extends Pipe {
+        error (t, e) {
+          super.error(t, e)
+          errorEventTime = t
+        }
+      }
+
+      const assertErrorTime = s => new AssertErrorTimeStream(s)
+
+      const s = assertErrorTime(switchLatest(at(1, disposeFailure(now(undefined)))))
+      return runEffects(s, ticks(2)).then(() => {
+        fail()
+      }, () => {
+        eq(1, errorEventTime)
+      })
+    });
+  });
 })


### PR DESCRIPTION
This fixes https://github.com/mostjs/core/issues/284.

I confirmed that the original `switchLatest` emits an error event with time `2`, which should be `1`, and removing ` + this.min` from `Segment#_dispose` resolves the issue.

To be honest, I find my way of writing test case pretty clumsy, but I could not find a  straightforward way to examine the case.
Feel free to request changes, I'll appreciate it.

Thank you.