### PR TITLE
Add `mergeMapConcurrently` type definition

### DIFF
--- a/packages/core/type-definitions/combinator/mergeConcurrently.d.ts
+++ b/packages/core/type-definitions/combinator/mergeConcurrently.d.ts
@@ -4,6 +4,8 @@ export function mergeConcurrently<A>(concurrency: number, s: Stream<Stream<A>>):
 export function mergeConcurrently<A>(concurrency: number): (s: Stream<Stream<A>>) => Stream<A>;
 
 export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>, concurrency: number, s: Stream<A>): Stream<B>;
-export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>): (concurrency: number, s: Stream<A>) => Stream<B>;
 export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>, concurrency: number): (s: Stream<A>) => Stream<B>;
-export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>): (concurrency: number) => (s: Stream<A>) => Stream<B>;
+export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>): {
+  (concurrency: number, s: Stream<A>): Stream<B>;
+  (concurrency: number): (s: Stream<A>) => Stream<B>;
+};

--- a/packages/core/type-definitions/combinator/mergeConcurrently.d.ts
+++ b/packages/core/type-definitions/combinator/mergeConcurrently.d.ts
@@ -2,3 +2,8 @@ import { Stream } from '@most/types';
 
 export function mergeConcurrently<A>(concurrency: number, s: Stream<Stream<A>>): Stream<A>;
 export function mergeConcurrently<A>(concurrency: number): (s: Stream<Stream<A>>) => Stream<A>;
+
+export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>, concurrency: number, s: Stream<A>): Stream<B>;
+export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>): (concurrency: number, s: Stream<A>) => Stream<B>;
+export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>, concurrency: number): (s: Stream<A>) => Stream<B>;
+export function mergeMapConcurrently<A, B>(f: (a: A) => Stream<B>): (concurrency: number) => (s: Stream<A>) => Stream<B>;


### PR DESCRIPTION
`mergeMapConcurrently` seems to be missing its type definition.
I have checked that copying-and-pasting these definitions into my project's `node_modules/@most/core/type-definitions/combinator/mergeConcurrently.d.ts` seemed suggest types as documented, but not tested seriously.