### PR TITLE
Fix mergeMapConcurrently flow type

### DIFF
--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -63,10 +63,12 @@ declare export function concatMap <A, B> (f: (A) => Stream<B>): (s: Stream<A>) =
 declare export function mergeConcurrently <A> (concurrency: number, s: Stream<Stream<A>>): Stream<A>
 declare export function mergeConcurrently <A> (concurrency: number): (s: Stream<Stream<A>>) => Stream<A>
 
-declare export function mergeMapConcurrently <A, B> (concurrency: number, f: (A) => Stream<B>, s: Stream<A>): Stream<B>
-declare export function mergeMapConcurrently <A, B> (concurrency: number): (f: (A) => Stream<B>, s: Stream<A>) => Stream<B>
-declare export function mergeMapConcurrently <A, B> (concurrency: number, f: (A) => Stream<B>): (s: Stream<A>) => Stream<B>
-declare export function mergeMapConcurrently <A, B> (concurrency: number): (f: (A) => Stream<B>) => (s: Stream<A>) => Stream<B>
+declare export function mergeMapConcurrently <A, B> (f: (A) => Stream<B>, concurrency: number, s: Stream<A>): Stream<B>
+declare export function mergeMapConcurrently <A, B> (f: (A) => Stream<B>, concurrency: number): (s: Stream<A>) => Stream<B>
+declare export function mergeMapConcurrently <A, B> (f: (A) => Stream<B>): {
+  (concurrency: number, s: Stream<A>): Stream<B>,
+  (concurrency: number): (s: Stream<A>) => Stream<B>
+}
 
 declare export function continueWith <A> (f: (any) => Stream<A>, s: Stream<A>): Stream<A>
 declare export function continueWith <A> (f: (any) => Stream<A>): (s: Stream<A>) => Stream<A>

--- a/packages/core/test/flow/combinator/mergeConcurrently.js
+++ b/packages/core/test/flow/combinator/mergeConcurrently.js
@@ -1,0 +1,15 @@
+// @flow
+import { mergeMapConcurrently, now, runEffects } from '../../../src/index'
+import { type Stream } from '@most/types'
+import { newDefaultScheduler } from '@most/scheduler'
+
+const s = now(123)
+const s1: Stream<number> = mergeMapConcurrently(now, 2, s)
+const s2: Stream<number> = mergeMapConcurrently(now, 2)(s)
+const s3: Stream<number> = mergeMapConcurrently(now)(2, s)
+const s4: Stream<number> = mergeMapConcurrently(now)(2)(s)
+
+runEffects(s1, newDefaultScheduler())
+runEffects(s2, newDefaultScheduler())
+runEffects(s3, newDefaultScheduler())
+runEffects(s4, newDefaultScheduler())


### PR DESCRIPTION
Fix #289 

This fixes parameter ordering to match the implementation (the first two params were reversed), and applies correctly represents currying for the 1-2 and 1-1-1 variants.  Flow type tests included.