### PR TITLE
Update perf tests

### DIFF
--- a/packages/core/test/perf/README.md
+++ b/packages/core/test/perf/README.md
@@ -6,184 +6,170 @@ Latest performance tests of basic most.js operations.
 ## Setup
 
 ```
-> uname -a
-Darwin Brians-MBP.home 16.3.0 Darwin Kernel Version 16.3.0: Thu Nov 17 20:23:58 PST 2016; root:xnu-3789.31.2~1/RELEASE_X86_64 x86_64
+❯ uname -a
+Darwin brian-mbp.home 18.5.0 Darwin Kernel Version 18.5.0: Mon Mar 11 20:40:32 PDT 2019; root:xnu-4903.251.3~3/RELEASE_X86_64 x86_64
 
-> npm ls
-most-perf@0.10.0 /Users/brian/Projects/cujojs/most/test/perf
-├── @reactivex/rxjs@5.0.1
-├── baconjs@0.7.89
-├── benchmark@2.1.0 (git://github.com/bestiejs/benchmark.js.git#308cc4c82df602b21bc7775075d43836969a8b16)
-├── highland@2.10.1
-├── kefir@3.6.1
-├── rx@4.1.0
-└── xstream@10.0.0
+❯ npm ls rxjs xstream kefir baconjs highland benchmark
+most-perf@0.10.0 /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+├── baconjs@3.0.3
+├── benchmark@2.1.4
+├── highland@2.13.4
+├── kefir@3.8.6
+├── rxjs@6.5.2
+└── xstream@11.11.0
 ```
 
 ## Node
 
 ```
-> node --version
-v6.9.2
+❯ node --version
+v12.1.0
 
-> npm start
+❯ npm start
 
-> most-perf@0.10.0 start /Users/brian/Projects/cujojs/most/test/perf
-> npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats
+> most-perf@0.10.0 start /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> npm run filter-map-reduce && npm run chain && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats && npm run switch
 
 
-> most-perf@0.10.0 filter-map-reduce /Users/brian/Projects/cujojs/most/test/perf
-> node ./filter-map-reduce
+> most-perf@0.10.0 filter-map-reduce /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./filter-map-reduce
 
 filter -> map -> reduce 1000000 integers
 -------------------------------------------------------
-most                568.23 op/s ±  1.43%   (80 samples)
-rx 4                  1.45 op/s ±  1.48%   (12 samples)
-rx 5                 11.38 op/s ±  1.29%   (55 samples)
-xstream              18.41 op/s ±  0.91%   (81 samples)
-kefir                10.36 op/s ±  1.11%   (51 samples)
-bacon                 0.83 op/s ±  1.93%    (9 samples)
-highland              4.82 op/s ±  1.90%   (27 samples)
+most                570.23 op/s ±  1.46%   (80 samples)
+rx 6                 39.10 op/s ±  2.97%   (63 samples)
+xstream              20.04 op/s ±  2.29%   (50 samples)
+kefir                15.18 op/s ±  1.58%   (70 samples)
+bacon                 2.71 op/s ±  2.24%   (18 samples)
+highland              4.16 op/s ±  2.60%   (25 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 flatMap /Users/brian/Projects/cujojs/most/test/perf
-> node ./flatMap.js
+> most-perf@0.10.0 chain /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./chain.js
 
-flatMap 1000 x 1000 streams
+chain 1000 x 1000 streams
 -------------------------------------------------------
-most                153.71 op/s ±  1.11%   (77 samples)
-rx 4                  0.75 op/s ±  2.24%    (8 samples)
-rx 5                 27.50 op/s ±  0.96%   (64 samples)
-xstream              11.99 op/s ±  0.98%   (57 samples)
-kefir                 9.30 op/s ±  1.13%   (47 samples)
-bacon                 0.73 op/s ±  1.29%    (8 samples)
-highland              0.10 op/s ±  3.44%    (5 samples)
+most                149.64 op/s ±  1.19%   (82 samples)
+rx 6                 84.77 op/s ± 10.56%   (79 samples)
+xstream              15.49 op/s ±  1.39%   (71 samples)
+kefir                13.72 op/s ±  1.82%   (65 samples)
+bacon                 1.94 op/s ±  1.81%   (14 samples)
+highland              0.32 op/s ±  2.96%    (6 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 concatMap /Users/brian/Projects/cujojs/most/test/perf
-> node ./concatMap.js
+> most-perf@0.10.0 concatMap /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./concatMap.js
 
 concatMap 1000 x 1000 streams
 -------------------------------------------------------
-most                103.87 op/s ±  1.24%   (77 samples)
-rx 4                  1.29 op/s ± 11.69%   (11 samples)
-rx 5                 29.58 op/s ±  1.12%   (68 samples)
-xstream              12.37 op/s ±  0.95%   (59 samples)
-kefir                10.13 op/s ±  0.99%   (50 samples)
-bacon                 0.70 op/s ±  3.40%    (8 samples)
+most                127.66 op/s ±  1.10%   (72 samples)
+rx 6                 85.24 op/s ± 11.93%   (80 samples)
+xstream              16.35 op/s ±  1.55%   (74 samples)
+kefir                13.66 op/s ±  1.63%   (64 samples)
+bacon                 1.93 op/s ±  2.62%   (14 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 merge /Users/brian/Projects/cujojs/most/test/perf
-> node ./merge.js
+> most-perf@0.10.0 merge /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./merge.js
 
 merge 100000 x 10 streams
 -------------------------------------------------------
-most                315.04 op/s ±  1.62%   (79 samples)
-rx 4                  1.36 op/s ±  1.59%   (11 samples)
-rx 5                 30.42 op/s ±  1.00%   (69 samples)
-xstream              16.87 op/s ±  1.15%   (75 samples)
-kefir                11.63 op/s ±  1.75%   (56 samples)
-bacon                 0.74 op/s ±  2.53%    (8 samples)
+most                205.24 op/s ±  1.65%   (80 samples)
+rx 6                 89.17 op/s ±  9.99%   (80 samples)
+xstream              28.31 op/s ±  2.95%   (67 samples)
+kefir                13.97 op/s ±  2.10%   (66 samples)
+bacon                 2.54 op/s ±  1.42%   (17 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 merge-nested /Users/brian/Projects/cujojs/most/test/perf
-> node ./merge-nested.js
+> most-perf@0.10.0 merge-nested /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./merge-nested.js
 
 merge nested streams w/depth 2, 5, 10, 100 (10000 items in each stream)
 -------------------------------------------------------
-most (depth 2)    11914.82 op/s ±  0.81%   (79 samples)
-most (depth 5)     6218.70 op/s ±  1.12%   (78 samples)
-most (depth 10)    3524.94 op/s ±  1.19%   (81 samples)
-most (depth 100)    305.40 op/s ±  1.89%   (79 samples)
-rx 4 (depth 2)       45.61 op/s ±  1.10%   (69 samples)
-rx 4 (depth 5)       16.34 op/s ±  0.95%   (73 samples)
-rx 4 (depth 10)       6.79 op/s ±  2.28%   (36 samples)
-rx 4 (depth 100)      0.18 op/s ±  2.54%    (5 samples)
-rx 5 (depth 2)      678.24 op/s ±  1.45%   (79 samples)
-rx 5 (depth 5)      268.50 op/s ±  2.52%   (78 samples)
-rx 5 (depth 10)      77.43 op/s ±  5.12%   (60 samples)
-rx 5 (depth 100)      1.63 op/s ±  5.42%   (13 samples)
-xstream (depth 2)   373.53 op/s ±  3.37%   (61 samples)
-xstream (depth 5)   152.53 op/s ±  3.18%   (64 samples)
-xstream (depth 10)   66.73 op/s ±  2.52%   (63 samples)
-xstream (depth 100)    1.32 op/s ±  1.01%   (11 samples)
-kefir (depth 2)     218.64 op/s ±  3.61%   (62 samples)
-kefir (depth 5)      79.75 op/s ±  2.76%   (62 samples)
-kefir (depth 10)     31.82 op/s ±  3.25%   (72 samples)
-kefir (depth 100)     0.47 op/s ±  2.10%    (7 samples)
-bacon (depth 2)      17.35 op/s ±  3.18%   (48 samples)
-bacon (depth 5)       7.33 op/s ±  2.98%   (38 samples)
-bacon (depth 10)      3.34 op/s ±  3.44%   (20 samples)
-bacon (depth 100)     0.08 op/s ±  3.85%    (5 samples)
-highland (depth 2)    1.75 op/s ± 13.30%   (13 samples)
-highland (depth 5)    1.78 op/s ±  9.74%   (13 samples)
-highland (depth 10)    0.14 op/s ±  2.89%    (5 samples)
+most (depth 2)     6809.98 op/s ±  1.51%   (78 samples)
+most (depth 5)     3481.37 op/s ±  1.43%   (81 samples)
+most (depth 10)    1895.50 op/s ±  1.49%   (81 samples)
+most (depth 100)    201.21 op/s ±  2.22%   (81 samples)
+rx 6 (depth 2)     1757.87 op/s ±  2.66%   (77 samples)
+rx 6 (depth 5)      637.94 op/s ±  2.02%   (80 samples)
+rx 6 (depth 10)     244.55 op/s ±  1.73%   (78 samples)
+rx 6 (depth 100)      2.95 op/s ±  2.95%   (19 samples)
+xstream (depth 2)   900.90 op/s ±  2.21%   (80 samples)
+xstream (depth 5)   324.19 op/s ±  1.01%   (84 samples)
+xstream (depth 10)  120.61 op/s ±  1.06%   (77 samples)
+xstream (depth 100)    1.70 op/s ±  2.52%   (13 samples)
+kefir (depth 2)     398.11 op/s ±  2.60%   (80 samples)
+kefir (depth 5)     134.14 op/s ±  1.72%   (79 samples)
+kefir (depth 10)     49.13 op/s ±  1.66%   (75 samples)
+kefir (depth 100)     0.57 op/s ±  5.17%    (7 samples)
+bacon (depth 2)      60.73 op/s ± 12.26%   (75 samples)
+bacon (depth 5)      27.29 op/s ±  1.44%   (64 samples)
+bacon (depth 10)     11.22 op/s ±  1.38%   (55 samples)
+bacon (depth 100)     0.16 op/s ± 19.71%    (5 samples)
+highland (depth 2)    3.30 op/s ±  8.28%   (21 samples)
+highland (depth 5)    3.39 op/s ±  4.85%   (21 samples)
+highland (depth 10)    0.38 op/s ±  2.03%    (6 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 zip /Users/brian/Projects/cujojs/most/test/perf
-> node ./zip.js
+> most-perf@0.10.0 zip /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./zip.js
 
 zip 2 x 100000 integers
 -------------------------------------------------------
-most                 91.66 op/s ±  3.23%   (61 samples)
-rx 4                  2.15 op/s ±  2.07%   (15 samples)
-rx 5                  0.20 op/s ±  1.33%    (5 samples)
-kefir                 0.46 op/s ± 51.48%    (7 samples)
-bacon                 0.10 op/s ±  8.01%    (5 samples)
-highland              0.06 op/s ±  7.44%    (5 samples)
+most                113.84 op/s ± 14.50%   (77 samples)
+rx 6                  0.88 op/s ±  3.00%    (9 samples)
+kefir                 0.87 op/s ±  1.74%    (9 samples)
+bacon                 0.09 op/s ± 10.27%    (5 samples)
+highland              0.07 op/s ±  2.22%    (5 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 scan /Users/brian/Projects/cujojs/most/test/perf
-> node ./scan.js
+> most-perf@0.10.0 scan /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./scan.js
 
 scan -> reduce 1000000 integers
 -------------------------------------------------------
-most                304.14 op/s ±  1.02%   (75 samples)
-rx 4                  1.19 op/s ±  2.28%   (10 samples)
-rx 5                 10.06 op/s ±  2.30%   (50 samples)
-xstream               7.87 op/s ±  1.25%   (40 samples)
-kefir                12.76 op/s ±  2.15%   (59 samples)
-bacon                 0.59 op/s ±  4.14%    (7 samples)
-highland              4.91 op/s ±  3.29%   (27 samples)
+most                330.25 op/s ±  1.09%   (80 samples)
+rx 6                 26.11 op/s ±  4.33%   (63 samples)
+xstream              15.08 op/s ±  1.85%   (69 samples)
+kefir                17.35 op/s ±  1.70%   (44 samples)
+bacon                 1.99 op/s ±  1.65%   (14 samples)
+highland              4.64 op/s ±  1.98%   (27 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 slice /Users/brian/Projects/cujojs/most/test/perf
-> node ./slice.js
+> most-perf@0.10.0 slice /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./slice.js
 
 skip(n/4) -> take(n/2) 1000000 integers
 -------------------------------------------------------
-most                101.20 op/s ±  1.77%   (65 samples)
-rx 4                  2.00 op/s ±  1.90%   (14 samples)
-rx 5                 40.24 op/s ±  1.81%   (62 samples)
-xstream              17.89 op/s ±  2.65%   (42 samples)
-kefir                 9.87 op/s ±  7.09%   (51 samples)
-bacon                 0.84 op/s ±  2.23%    (9 samples)
-highland              6.17 op/s ±  2.67%   (33 samples)
+most                237.70 op/s ±  1.25%   (79 samples)
+rx 6                148.89 op/s ±  1.06%   (81 samples)
+xstream              21.92 op/s ±  1.86%   (52 samples)
+kefir                15.49 op/s ±  8.02%   (73 samples)
+bacon                 3.27 op/s ±  2.80%   (20 samples)
+highland              5.16 op/s ±  1.56%   (28 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 skipRepeats /Users/brian/Projects/cujojs/most/test/perf
-> node ./skipRepeats.js
+> most-perf@0.10.0 skipRepeats /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./skipRepeats.js
 
 skipRepeats -> reduce 2 x 1000000 integers
 -------------------------------------------------------
-most                327.55 op/s ±  1.01%   (76 samples)
-rx 4                  1.60 op/s ±  1.40%   (12 samples)
-rx 5                 10.71 op/s ±  1.74%   (52 samples)
-xstream              18.89 op/s ±  1.82%   (47 samples)
-kefir                10.99 op/s ±  2.19%   (53 samples)
-bacon                 0.73 op/s ±  1.89%    (8 samples)
+most                350.57 op/s ±  1.13%   (80 samples)
+rx 6                119.72 op/s ±  0.80%   (75 samples)
+xstream              31.36 op/s ±  3.70%   (71 samples)
+kefir                17.36 op/s ± 18.44%   (50 samples)
+bacon                 2.88 op/s ±  1.85%   (19 samples)
 -------------------------------------------------------
 
-> most-perf@0.10.0 switch /Users/brian/Projects/cujojs/@most/core/test/perf
-> node ./switch.js
+> most-perf@0.10.0 switch /Users/brian/Projects/cujojs/@most/core/packages/core/test/perf
+> babel-node --presets env ./switch.js
 
 switch 10000 x 1000 streams
 -------------------------------------------------------
-most               1799.37 op/s ±  6.12%   (79 samples)
-rx 5                  1.71 op/s ±  7.66%   (13 samples)
-rx 4                107.66 op/s ±  1.09%   (79 samples)
-xstream               1.32 op/s ±  5.23%   (11 samples)
-kefir                 1.04 op/s ±  7.82%    (9 samples)
-bacon                 0.03 op/s ±  6.27%    (5 samples)
+most               1160.19 op/s ±  2.87%   (77 samples)
+rx 6                  9.66 op/s ±  4.92%   (49 samples)
+xstream               1.36 op/s ±  1.41%   (11 samples)
+kefir                 1.41 op/s ±  2.54%   (11 samples)
+bacon                 0.06 op/s ±  0.97%    (5 samples)
 -------------------------------------------------------
 ```

--- a/packages/core/test/perf/chain.js
+++ b/packages/core/test/perf/chain.js
@@ -1,85 +1,71 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {chain} = require('../../src/index');
-const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const Benchmark = require('benchmark')
+const { chain } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
-const mostFromArray = runners.mostFromArray
-const xstreamFlattenConcurrently = require('xstream/extra/flattenConcurrently').default;
+const { getIntArg2, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon, runHighland } = require('./runners')
+const xstreamFlattenConcurrently = require('xstream/extra/flattenConcurrently').default
 
 // flatMapping n streams, each containing m items.
 // Results in a single stream that merges in n x m items
 // In Array parlance: Take an Array containing n Arrays, each of length m,
 // and flatten it to an Array of length n x m.
-const mn = runners.getIntArg2(1000, 1000);
-const a = build(mn[0], mn[1]);
+const mn = getIntArg2(1000, 1000)
+const a = build(mn[0], mn[1])
 
-function build(m, n) {
-  const a = new Array(n);
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = buildArray(i*1000, m);
+function build (m, n) {
+  const a = new Array(n)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = buildArray(i * 1000, m)
   }
-  return a;
+  return a
 }
 
-function buildArray(base, n) {
-  const a = new Array(n);
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = base + i;
+function buildArray (base, n) {
+  const a = new Array(n)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = base + i
   }
-  return a;
+  return a
 }
 
-const suite = Benchmark.Suite('chain ' + mn[0] + ' x ' + mn[1] + ' streams');
+const suite = Benchmark.Suite('chain ' + mn[0] + ' x ' + mn[1] + ' streams')
 const options = {
   defer: true,
-  onError: function(e) {
-    e.currentTarget.failure = e.error;
+  onError: function (e) {
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, chain(mostFromArray, mostFromArray(a))));
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(sum, 0, chain(mostFromArray, mostFromArray(a))))
   }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).flatMap(rx.Observable.fromArray).reduce(sum, 0));
+  .add('rx 6', function (deferred) {
+    runRx6(deferred,
+      rx.from(a).pipe(rxo.flatMap(function (x) { return rx.from(x) })).pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred,
-      rxjs.Observable.from(a).flatMap(
-        function(x) {return rxjs.Observable.from(x)}).reduce(sum, 0))
+  .add('xstream', function (deferred) {
+    runXstream(deferred, xs.fromArray(a).map(xs.fromArray).compose(xstreamFlattenConcurrently).fold(sum, 0).last())
   }, options)
-  .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).map(xs.fromArray).compose(xstreamFlattenConcurrently).fold(sum, 0).last());
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0).last());
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.fromArray(a).flatMap(bacon.fromArray).reduce(0, sum))
   }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).flatMap(bacon.fromArray).reduce(0, sum));
+  .add('highland', function (deferred) {
+    runHighland(deferred, highland(a).flatMap(highland).reduce(0, sum))
   }, options)
-  .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).flatMap(highland).reduce(0, sum));
-  }, options);
 
-runners.runSuite(suite);
+runSuite(suite)
 
-function sum(x, y) {
-  return x + y;
-}
-
-function even(x) {
-  return x % 2 === 0;
-}
-
-function identity(x) {
-  return x;
+function sum (x, y) {
+  return x + y
 }

--- a/packages/core/test/perf/concatMap.js
+++ b/packages/core/test/perf/concatMap.js
@@ -1,79 +1,70 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {concatMap} = require('../../src/index');
-const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs');
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const xs = require('xstream').default;
+const Benchmark = require('benchmark')
+const { concatMap } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
+const bacon = require('baconjs')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
-const mostFromArray = runners.mostFromArray;
-const xstreamFlattenSequentially = require('xstream/extra/flattenSequentially').default;
+const { getIntArg2, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon } = require('./runners')
+
+const xstreamFlattenSequentially = require('xstream/extra/flattenSequentially').default
 
 // flatMapping n streams, each containing m items.
 // Results in a single stream that merges in m x n items
 // In Array parlance: Take an Array containing m Arrays, each of length n,
 // and flatten it to an Array of length m x n.
-const mn = runners.getIntArg2(1000, 1000);
-const a = build(mn[0], mn[1]);
+const mn = getIntArg2(1000, 1000)
+const a = build(mn[0], mn[1])
 
-function build(m, n) {
-  const a = new Array(n);
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = buildArray(i*1000, m);
+function build (m, n) {
+  const a = new Array(n)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = buildArray(i * 1000, m)
   }
-  return a;
+  return a
 }
 
-function buildArray(base, n) {
-  const a = new Array(n);
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = base + i;
+function buildArray (base, n) {
+  const a = new Array(n)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = base + i
   }
-  return a;
+  return a
 }
 
-const suite = Benchmark.Suite('concatMap ' + mn[0] + ' x ' + mn[1] + ' streams');
+const suite = Benchmark.Suite('concatMap ' + mn[0] + ' x ' + mn[1] + ' streams')
 const options = {
   defer: true,
-  onError: function(e) {
-    e.currentTarget.failure = e.error;
+  onError: function (e) {
+    e.currentTarget.failure = e.error
   }
-};
-
-suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, concatMap(mostFromArray, mostFromArray(a))));
-  }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).concatMap(rx.Observable.fromArray).reduce(sum, 0));
-  }, options)
-  .add('rx 5', function(deffered) {
-    runners.runRx5(deffered, rxjs.Observable.from(a).concatMap(function(x) {return rxjs.Observable.from(x)}).reduce(sum, 0))
-  }, options)
-  .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).map(xs.fromArray).compose(xstreamFlattenSequentially).fold(sum, 0).last())
-  }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0).last());
-  }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).flatMapConcat(bacon.fromArray).reduce(0, sum));
-  }, options)
-  // Highland doesn't have concatMap
-  //.add('highland', function(deferred) {
-  //  runners.runHighland(deferred, highland(a).flatMap(highland).reduce(0, sum));
-  //}, options);
-
-runners.runSuite(suite);
-
-function sum(x, y) {
-  return x + y;
 }
 
-function identity(x) {
-  return x;
+suite
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(sum, 0, concatMap(mostFromArray, mostFromArray(a))))
+  }, options)
+  .add('rx 6', function (deferred) {
+    runRx6(deferred, rx.from(a).pipe(rxo.concatMap(x => rx.from(x))).pipe(rxo.reduce(sum, 0)))
+  }, options)
+  .add('xstream', function (deferred) {
+    runXstream(deferred, xs.fromArray(a).map(xs.fromArray).compose(xstreamFlattenSequentially).fold(sum, 0).last())
+  }, options)
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0).last())
+  }, options)
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.fromArray(a).flatMapConcat(bacon.fromArray).reduce(0, sum))
+  }, options)
+  // Highland doesn't have concatMap
+  // .add('highland', function (deferred) {
+  //   runHighland(deferred, highland (a).flatMap (highland).reduce(0, sum))
+  // }, options)
+
+runSuite(suite)
+
+function sum (x, y) {
+  return x + y
 }

--- a/packages/core/test/perf/merge-nested.js
+++ b/packages/core/test/perf/merge-nested.js
@@ -1,194 +1,200 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {merge: _merge} = require('../../src/index');
-const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const Benchmark = require('benchmark')
+const { merge } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
-const mostFromArray = runners.mostFromArray
+const { getIntArg, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon, runHighland } = require('./runners')
+
 xs.prototype.merge = function (s) { return xs.merge(this, s) }
 
 // Merging n streams, each containing m items.
 // Results in a single stream that merges in n x m items
 // In Array parlance: Take an Array containing n Arrays, each of length m,
 // and flatten it to an Array of length n x m.
-const n = runners.getIntArg(10000);
-const a = buildArray(n);
+const n = getIntArg(10000)
+const a = buildArray(n)
 
-function buildArray(n) {
-  const a = new Array(n);
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = i;
+function buildArray (n) {
+  const a = new Array(n)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = i
   }
-  return a;
+  return a
 }
 
-function merge(n, create) {
-  let s = create(a);
-  for(let i=0; i<n; ++i) {
-    s = s.merge(create(a))
+function mergeRx (n) {
+  let s = rx.from(a)
+  for (let i = 0; i < n; ++i) {
+    s = s.pipe(rxo.merge(rx.from(a)))
   }
-  return s;
+  return s
 }
 
-function mergeMost(n, create) {
-  let s = create(a);
-  for(let i=0; i<n; ++i) {
-    s = _merge(create(a), s)
+function mergeMost (n) {
+  let s = mostFromArray(a)
+  for (let i = 0; i < n; ++i) {
+    s = merge(mostFromArray(a), s)
   }
-  return s;
+  return s
 }
 
+function mergeXstream (n) {
+  let s = xs.fromArray(a)
+  for (let i = 0; i < n; ++i) {
+    s = xs.merge(xs.fromArray(a), s)
+  }
+  return s
+}
 
-function mergeHighland(n) {
+function mergeKefir (n) {
+  let s = kefirFromArray(a)
+  for (let i = 0; i < n; ++i) {
+    s = s.merge(kefirFromArray(a))
+  }
+  return s
+}
+
+function mergeBacon (n) {
+  let s = bacon.fromArray(a)
+  for (let i = 0; i < n; ++i) {
+    s = s.merge(bacon.fromArray(a))
+  }
+  return s
+}
+
+function mergeHighland (n) {
   // HELP WANTED: Is there a better way to do this in highland?
   // The two approaches below perform similarly
-  let s = highland(a);
-  for(let i=0; i<n; ++i) {
-    s = highland([s, highland(a)]).merge();
+  let s = highland(a)
+  for (let i = 0; i < n; ++i) {
+    s = highland([s, highland(a)]).merge()
   }
-  return s;
+  return s
 }
 
-const suite = Benchmark.Suite('merge nested streams w/depth 2, 5, 10, 100 (' + n + ' items in each stream)');
+const suite = Benchmark.Suite('merge nested streams w/depth 2, 5, 10, 100 (' + n + ' items in each stream)')
 const options = {
   defer: true,
-  onError: function(e) {
-    e.currentTarget.failure = e.error;
+  onError: function (e) {
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
-  .add('most (depth 2)', function(deferred) {
-    const s = mergeMost(2, mostFromArray);
-    runners.runMost(deferred, reduce(sum, 0, s));
+  .add('most (depth 2)', function (deferred) {
+    const s = mergeMost(2)
+    runMost(deferred, reduce(sum, 0, s))
   }, options)
-  .add('most (depth 5)', function(deferred) {
-    const s = mergeMost(5, mostFromArray);
-    runners.runMost(deferred, reduce(sum, 0, s));
+  .add('most (depth 5)', function (deferred) {
+    const s = mergeMost(5)
+    runMost(deferred, reduce(sum, 0, s))
   }, options)
-  .add('most (depth 10)', function(deferred) {
-    const s = mergeMost(10, mostFromArray);
-    runners.runMost(deferred, reduce(sum, 0, s));
+  .add('most (depth 10)', function (deferred) {
+    const s = mergeMost(10)
+    runMost(deferred, reduce(sum, 0, s))
   }, options)
-  .add('most (depth 100)', function(deferred) {
-    const s = mergeMost(100, mostFromArray);
-    runners.runMost(deferred, reduce(sum, 0, s));
+  .add('most (depth 100)', function (deferred) {
+    const s = mergeMost(100)
+    runMost(deferred, reduce(sum, 0, s))
   }, options)
-  // .add('most (depth 1000)', function(deferred) {
-  //   const s = merge(1000, most.from);
-  //   runners.runMost(deferred, s.reduce(sum, 0));
+  // .add('most (depth 1000)', function deferred) {
+  //   const s = mergeMost(1000)
+  //   runMost(deferred, reduce(sum, 0, s))
   // }, options)
-  // .add('most (depth 10000)', function(deferred) {
-  //   const s = merge(10000, most.from);
-  //   runners.runMost(deferred, s.reduce(sum, 0));
+  // .add('most (depth 10000)', function (deferred) {
+  //   const s = mergeMost(10000)
+  //   runMost(deferred, reduce(sum, 0, s))
   // }, options)
-  .add('rx 4 (depth 2)', function(deferred) {
-    const s = merge(2, rx.Observable.fromArray);
-    runners.runRx(deferred, s.reduce(sum, 0));
+  .add('rx 6 (depth 2)', function (deferred) {
+    const s = mergeRx(2)
+    runRx6(deferred, s.pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 4 (depth 5)', function(deferred) {
-    const s = merge(5, rx.Observable.fromArray);
-    runners.runRx(deferred, s.reduce(sum, 0));
+  .add('rx 6 (depth 5)', function (deferred) {
+    const s = mergeRx(5)
+    runRx6(deferred, s.pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 4 (depth 10)', function(deferred) {
-    const s = merge(10, rx.Observable.fromArray);
-    runners.runRx(deferred, s.reduce(sum, 0));
+  .add('rx 6 (depth 10)', function (deferred) {
+    const s = mergeRx(10)
+    runRx6(deferred, s.pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 4 (depth 100)', function(deferred) {
-    const s = merge(100, rx.Observable.fromArray);
-    runners.runRx(deferred, s.reduce(sum, 0));
+  .add('rx 6 (depth 100)', function (deferred) {
+    const s = mergeRx(100)
+    runRx6(deferred, s.pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 5 (depth 2)', function(deferred) {
-    const s = merge(2, function(x) {return rxjs.Observable.from(x)});
-    runners.runRx5(deferred, s.reduce(sum, 0));
+  .add('xstream (depth 2)', function (deferred) {
+    const s = mergeXstream(2)
+    runXstream(deferred, s.fold(sum, 0).last())
   }, options)
-  .add('rx 5 (depth 5)', function(deferred) {
-    const s = merge(5, function(x) {return rxjs.Observable.from(x)});
-    runners.runRx5(deferred, s.reduce(sum, 0));
+  .add('xstream (depth 5)', function (deferred) {
+    const s = mergeXstream(5)
+    runXstream(deferred, s.fold(sum, 0).last())
   }, options)
-  .add('rx 5 (depth 10)', function(deferred) {
-    const s = merge(10, function(x) {return rxjs.Observable.from(x)});
-    runners.runRx5(deferred, s.reduce(sum, 0));
+  .add('xstream (depth 10)', function (deferred) {
+    const s = mergeXstream(10)
+    runXstream(deferred, s.fold(sum, 0).last())
   }, options)
-  .add('rx 5 (depth 100)', function(deferred) {
-    const s = merge(100, function(x) {return rxjs.Observable.from(x)});
-    runners.runRx5(deferred, s.reduce(sum, 0));
+  .add('xstream (depth 100)', function (deferred) {
+    const s = mergeXstream(100)
+    runXstream(deferred, s.fold(sum, 0).last())
   }, options)
-  .add('xstream (depth 2)', function(deferred) {
-    const s = merge(2, xs.fromArray);
-    runners.runXstream(deferred, s.fold(sum, 0).last());
+  .add('kefir (depth 2)', function (deferred) {
+    const s = mergeKefir(2)
+    runKefir(deferred, s.scan(sum, 0).last())
   }, options)
-  .add('xstream (depth 5)', function(deferred) {
-    const s = merge(5, xs.fromArray);
-    runners.runXstream(deferred, s.fold(sum, 0).last());
+  .add('kefir (depth 5)', function (deferred) {
+    const s = mergeKefir(5)
+    runKefir(deferred, s.scan(sum, 0).last())
   }, options)
-  .add('xstream (depth 10)', function(deferred) {
-    const s = merge(10, xs.fromArray);
-    runners.runXstream(deferred, s.fold(sum, 0).last());
+  .add('kefir (depth 10)', function (deferred) {
+    const s = mergeKefir(10)
+    runKefir(deferred, s.scan(sum, 0).last())
   }, options)
-  .add('xstream (depth 100)', function(deferred) {
-    const s = merge(100, xs.fromArray);
-    runners.runXstream(deferred, s.fold(sum, 0).last());
+  .add('kefir (depth 100)', function (deferred) {
+    const s = mergeKefir(100)
+    runKefir(deferred, s.scan(sum, 0).last())
   }, options)
-  .add('kefir (depth 2)', function(deferred) {
-    const s = merge(2, kefirFromArray)
-    runners.runKefir(deferred, s.scan(sum, 0).last());
+  .add('bacon (depth 2)', function (deferred) {
+    const s = mergeBacon(2)
+    runBacon(deferred, s.reduce(0, sum))
   }, options)
-  .add('kefir (depth 5)', function(deferred) {
-    const s = merge(5, kefirFromArray)
-    runners.runKefir(deferred, s.scan(sum, 0).last());
+  .add('bacon (depth 5)', function (deferred) {
+    const s = mergeBacon(5)
+    runBacon(deferred, s.reduce(0, sum))
   }, options)
-  .add('kefir (depth 10)', function(deferred) {
-    const s = merge(10, kefirFromArray)
-    runners.runKefir(deferred, s.scan(sum, 0).last());
+  .add('bacon (depth 10)', function (deferred) {
+    const s = mergeBacon(10)
+    runBacon(deferred, s.reduce(0, sum))
   }, options)
-  .add('kefir (depth 100)', function(deferred) {
-    const s = merge(100, kefirFromArray)
-    runners.runKefir(deferred, s.scan(sum, 0).last());
+  .add('bacon (depth 100)', function (deferred) {
+    const s = mergeBacon(100)
+    runBacon(deferred, s.reduce(0, sum))
   }, options)
-  .add('bacon (depth 2)', function(deferred) {
-    const s = merge(2, bacon.fromArray);
-    runners.runBacon(deferred, s.reduce(0, sum));
-  }, options)
-  .add('bacon (depth 5)', function(deferred) {
-    const s = merge(5, bacon.fromArray);
-    runners.runBacon(deferred, s.reduce(0, sum));
-  }, options)
-  .add('bacon (depth 10)', function(deferred) {
-    const s = merge(10, bacon.fromArray);
-    runners.runBacon(deferred, s.reduce(0, sum));
-  }, options)
-  .add('bacon (depth 100)', function(deferred) {
-    const s = merge(100, bacon.fromArray);
-    runners.runBacon(deferred, s.reduce(0, sum));
-  }, options)
-  .add('highland (depth 2)', function(deferred) {
+  .add('highland (depth 2)', function (deferred) {
     const s = mergeHighland(2)
-    runners.runHighland(deferred, s.reduce(0, sum));
+    runHighland(deferred, s.reduce(0, sum))
   }, options)
-  .add('highland (depth 5)', function(deferred) {
+  .add('highland (depth 5)', function (deferred) {
     const s = mergeHighland(2)
-    runners.runHighland(deferred, s.reduce(0, sum));
+    runHighland(deferred, s.reduce(0, sum))
   }, options)
-  .add('highland (depth 10)', function(deferred) {
+  .add('highland (depth 10)', function (deferred) {
     const s = mergeHighland(10)
-    runners.runHighland(deferred, s.reduce(0, sum));
+    runHighland(deferred, s.reduce(0, sum))
   }, options)
   // WARNING: Never finishes at 10k items
   // .add('highland (depth 100)', function(deferred) {
   //   const s = mergeHighland(100)
-  //   runners.runHighland(deferred, s.reduce(0, sum));
+  //   runHighland(deferred, s.reduce(0, sum))
   // }, options)
 
-runners.runSuite(suite);
+runSuite(suite)
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }

--- a/packages/core/test/perf/merge.js
+++ b/packages/core/test/perf/merge.js
@@ -1,86 +1,86 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {mergeArray} = require('../../src/index');
+const Benchmark = require('benchmark')
+const {mergeArray} = require('../../src/index')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
+const rx = require('rx')
 const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
 
 // Merging n streams, each containing m items.
 // Results in a single stream that merges in n x m items
 // In Array parlance: Take an Array containing n Arrays, each of length m,
 // and flatten it to an Array of length n x m.
-const mn = runners.getIntArg2(100000, 10);
-const a = build(mn[0], mn[1]);
+const mn = runners.getIntArg2(100000, 10)
+const a = build(mn[0], mn[1])
 
 function build(m, n) {
-  const a = new Array(n);
+  const a = new Array(n)
   for(let i = 0; i< a.length; ++i) {
-    a[i] = buildArray(i*1000, m);
+    a[i] = buildArray(i*1000, m)
   }
-  return a;
+  return a
 }
 
 function buildArray(base, n) {
-  const a = new Array(n);
+  const a = new Array(n)
   for(let i = 0; i< a.length; ++i) {
-    a[i] = base + i;
+    a[i] = base + i
   }
-  return a;
+  return a
 }
 
-const suite = Benchmark.Suite('merge ' + mn[0] + ' x ' + mn[1] + ' streams');
+const suite = Benchmark.Suite('merge ' + mn[0] + ' x ' + mn[1] + ' streams')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
   .add('most', function(deferred) {
-    const streams = a.map(mostFromArray);
-    runners.runMost(deferred, reduce(sum, 0, mergeArray(streams)));
+    const streams = a.map(mostFromArray)
+    runners.runMost(deferred, reduce(sum, 0, mergeArray(streams)))
   }, options)
   .add('rx 4', function(deferred) {
-    const streams = a.map(rx.Observable.fromArray);
-    runners.runRx(deferred, rx.Observable.merge.apply(void 0, streams).reduce(sum, 0));
+    const streams = a.map(rx.Observable.fromArray)
+    runners.runRx(deferred, rx.Observable.merge.apply(void 0, streams).reduce(sum, 0))
   }, options)
   .add('rx 5', function(deferred) {
-    const streams = a.map(function(x) {return rxjs.Observable.from(x)});
+    const streams = a.map(function(x) {return rxjs.Observable.from(x)})
     runners.runRx5(deferred,
       rxjs.Observable.merge.apply(rxjs.Observable, streams).reduce(sum, 0))
   }, options)
   .add('xstream', function(deferred) {
-    const streams = a.map(xs.fromArray);
+    const streams = a.map(xs.fromArray)
     runners.runXstream(deferred, xs.merge.apply(xs, streams).fold(sum, 0).last())
   }, options)
   .add('kefir', function(deferred) {
-    const streams = a.map(kefirFromArray);
-    runners.runKefir(deferred, kefir.merge(streams).scan(sum, 0).last());
+    const streams = a.map(kefirFromArray)
+    runners.runKefir(deferred, kefir.merge(streams).scan(sum, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    const streams = a.map(bacon.fromArray);
-    runners.runBacon(deferred, bacon.mergeAll(streams).reduce(0, sum));
+    const streams = a.map(bacon.fromArray)
+    runners.runBacon(deferred, bacon.mergeAll(streams).reduce(0, sum))
   }, options)
   // .add('highland', function(deferred) {
   // Commented out because it never finishes on Node >= 6.9.1 on my machine
   //   // HELP WANTED: Is there a better way to do this in highland?
   //   // The two approaches below perform similarly
-  //   const streams = a.map(highland);
-  //   runners.runHighland(deferred, highland(streams).merge().reduce(0, sum));
-  //   //runners.runHighland(deferred, highland(streams).flatMap(identity).reduce(0, sum));
-  // }, options);
+  //   const streams = a.map(highland)
+  //   runners.runHighland(deferred, highland(streams).merge().reduce(0, sum))
+  //   //runners.runHighland(deferred, highland(streams).flatMap(identity).reduce(0, sum))
+  // }, options)
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }

--- a/packages/core/test/perf/merge.js
+++ b/packages/core/test/perf/merge.js
@@ -1,36 +1,34 @@
 require('babel-register')
 const Benchmark = require('benchmark')
-const {mergeArray} = require('../../src/index')
-const {reduce} = require('../helper/reduce')
-const rx = require('rx')
-const rxjs = require('@reactivex/rxjs')
+const { mergeArray } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
 const kefir = require('kefir')
 const bacon = require('baconjs')
-const highland = require('highland')
+// const highland = require('highland')
 const xs = require('xstream').default
 
-const runners = require('./runners')
-const kefirFromArray = runners.kefirFromArray
-const mostFromArray = runners.mostFromArray
+const { getIntArg2, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon } = require('./runners')
 
 // Merging n streams, each containing m items.
 // Results in a single stream that merges in n x m items
 // In Array parlance: Take an Array containing n Arrays, each of length m,
 // and flatten it to an Array of length n x m.
-const mn = runners.getIntArg2(100000, 10)
+const mn = getIntArg2(100000, 10)
 const a = build(mn[0], mn[1])
 
-function build(m, n) {
+function build (m, n) {
   const a = new Array(n)
-  for(let i = 0; i< a.length; ++i) {
-    a[i] = buildArray(i*1000, m)
+  for (let i = 0; i < a.length; ++i) {
+    a[i] = buildArray(i * 1000, m)
   }
   return a
 }
 
-function buildArray(base, n) {
+function buildArray (base, n) {
   const a = new Array(n)
-  for(let i = 0; i< a.length; ++i) {
+  for (let i = 0; i < a.length; ++i) {
     a[i] = base + i
   }
   return a
@@ -39,48 +37,44 @@ function buildArray(base, n) {
 const suite = Benchmark.Suite('merge ' + mn[0] + ' x ' + mn[1] + ' streams')
 const options = {
   defer: true,
-  onError: function(e) {
+  onError: function (e) {
     e.currentTarget.failure = e.error
   }
 }
 
 suite
-  .add('most', function(deferred) {
+  .add('most', function (deferred) {
     const streams = a.map(mostFromArray)
-    runners.runMost(deferred, reduce(sum, 0, mergeArray(streams)))
+    runMost(deferred, reduce(sum, 0, mergeArray(streams)))
   }, options)
-  .add('rx 4', function(deferred) {
-    const streams = a.map(rx.Observable.fromArray)
-    runners.runRx(deferred, rx.Observable.merge.apply(void 0, streams).reduce(sum, 0))
+  .add('rx 6', function (deferred) {
+    const streams = a.map(a => rx.from(a))
+    runRx6(deferred,
+      rx.merge(...streams).pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    const streams = a.map(function(x) {return rxjs.Observable.from(x)})
-    runners.runRx5(deferred,
-      rxjs.Observable.merge.apply(rxjs.Observable, streams).reduce(sum, 0))
-  }, options)
-  .add('xstream', function(deferred) {
+  .add('xstream', function (deferred) {
     const streams = a.map(xs.fromArray)
-    runners.runXstream(deferred, xs.merge.apply(xs, streams).fold(sum, 0).last())
+    runXstream(deferred, xs.merge.apply(xs, streams).fold(sum, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
+  .add('kefir', function (deferred) {
     const streams = a.map(kefirFromArray)
-    runners.runKefir(deferred, kefir.merge(streams).scan(sum, 0).last())
+    runKefir(deferred, kefir.merge(streams).scan(sum, 0).last())
   }, options)
-  .add('bacon', function(deferred) {
+  .add('bacon', function (deferred) {
     const streams = a.map(bacon.fromArray)
-    runners.runBacon(deferred, bacon.mergeAll(streams).reduce(0, sum))
+    runBacon(deferred, bacon.mergeAll(streams).reduce(0, sum))
   }, options)
-  // .add('highland', function(deferred) {
+  // .add('highland', function (deferred) {
   // Commented out because it never finishes on Node >= 6.9.1 on my machine
   //   // HELP WANTED: Is there a better way to do this in highland?
   //   // The two approaches below perform similarly
   //   const streams = a.map(highland)
-  //   runners.runHighland(deferred, highland(streams).merge().reduce(0, sum))
-  //   //runners.runHighland(deferred, highland(streams).flatMap(identity).reduce(0, sum))
+  //   runHighland(deferred, highland(streams).merge().reduce(0, sum))
+  //   //runHighland(deferred, highland(streams).flatMap(identity).reduce(0, sum))
   // }, options)
 
-runners.runSuite(suite)
+runSuite(suite)
 
-function sum(x, y) {
+function sum (x, y) {
   return x + y
 }

--- a/packages/core/test/perf/package-lock.json
+++ b/packages/core/test/perf/package-lock.json
@@ -4,14 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@reactivex/rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-mQedi1gQZFURTsyQI8NPjhJOV6XpMFn7Y+fLh7W/JSyH6XQ5UAjJlKX5khA6S9B7/xWNABKeZ+NLzBWpH9iBnQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -1905,11 +1897,6 @@
       "requires": {
         "is-finite": "^1.0.0"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rxjs": {
       "version": "6.5.2",

--- a/packages/core/test/perf/package-lock.json
+++ b/packages/core/test/perf/package-lock.json
@@ -5,18 +5,11 @@
   "requires": true,
   "dependencies": {
     "@reactivex/rxjs": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-5.5.10.tgz",
-      "integrity": "sha512-GbnJyomGVj8KFpd8tN4Bz4S8fFLDzJbGDn9QHe1wxXZ3pqfqNK3oIxwGQkqhmhPkEbleF6PNEFu6aFQho9HoRw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-mQedi1gQZFURTsyQI8NPjhJOV6XpMFn7Y+fLh7W/JSyH6XQ5UAjJlKX5khA6S9B7/xWNABKeZ+NLzBWpH9iBnQ==",
       "requires": {
-        "symbol-observable": "1.0.1"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-        }
+        "tslib": "^1.9.0"
       }
     },
     "ansi-regex": {
@@ -1918,6 +1911,14 @@
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -1989,6 +1990,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "user-home": {
       "version": "1.1.1",

--- a/packages/core/test/perf/package.json
+++ b/packages/core/test/perf/package.json
@@ -19,7 +19,7 @@
     "start": "npm run filter-map-reduce && npm run chain && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats && npm run switch"
   },
   "dependencies": {
-    "@reactivex/rxjs": "^5.5.10",
+    "@reactivex/rxjs": "^6.5.2",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
@@ -28,6 +28,7 @@
     "highland": "^2.13.4",
     "kefir": "^3.8.6",
     "rx": "^4.1.0",
+    "rxjs": "^6.5.2",
     "xstream": "^11.11.0"
   }
 }

--- a/packages/core/test/perf/package.json
+++ b/packages/core/test/perf/package.json
@@ -19,7 +19,6 @@
     "start": "npm run filter-map-reduce && npm run chain && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats && npm run switch"
   },
   "dependencies": {
-    "@reactivex/rxjs": "^6.5.2",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
@@ -27,7 +26,6 @@
     "benchmark": "^2.1.4",
     "highland": "^2.13.4",
     "kefir": "^3.8.6",
-    "rx": "^4.1.0",
     "rxjs": "^6.5.2",
     "xstream": "^11.11.0"
   }

--- a/packages/core/test/perf/runners.js
+++ b/packages/core/test/perf/runners.js
@@ -1,61 +1,62 @@
-var kefir = require('kefir');
-kefir.DEPRECATION_WARNINGS = false;
+var kefir = require('kefir')
+kefir.DEPRECATION_WARNINGS = false
 
-exports.runSuite       = runSuite;
+exports.runSuite       = runSuite
 
-exports.mostFromArray  = mostFromArray;
-exports.runMost        = runMost;
-exports.runRx          = runRx;
-exports.runRx5         = runRx5;
-exports.runKefir       = runKefir;
-exports.kefirFromArray = kefirFromArray;
-exports.runBacon       = runBacon;
-exports.runHighland    = runHighland;
-exports.runXstream     = runXstream;
+exports.mostFromArray  = mostFromArray
+exports.runMost        = runMost
+exports.runRx          = runRx
+exports.runRx5         = runRx5
+exports.runRx6         = runRx6
+exports.runKefir       = runKefir
+exports.kefirFromArray = kefirFromArray
+exports.runBacon       = runBacon
+exports.runHighland    = runHighland
+exports.runXstream     = runXstream
 
-exports.getIntArg      = getIntArg;
-exports.getIntArg2     = getIntArg2;
-exports.logResults     = logResults;
+exports.getIntArg      = getIntArg
+exports.getIntArg2     = getIntArg2
+exports.logResults     = logResults
 
 function noop() {}
 
 function _getIntArg(defaultValue, index) {
-  var n = parseInt(process.argv[index]);
-  return isNaN(n) ? defaultValue : n;
+  var n = parseInt(process.argv[index])
+  return isNaN(n) ? defaultValue : n
 }
 
 function getIntArg(defaultValue) {
-  return _getIntArg(defaultValue, process.argv.length - 1);
+  return _getIntArg(defaultValue, process.argv.length - 1)
 }
 
 function getIntArg2(default1, default2) {
-  var m = _getIntArg(default1, process.argv.length - 2);
-  var n = _getIntArg(default2, process.argv.length - 1);
-  return [m, n];
+  var m = _getIntArg(default1, process.argv.length - 2)
+  var n = _getIntArg(default2, process.argv.length - 1)
+  return [m, n]
 }
 
 function logResults(e) {
-  var t = e.target;
+  var t = e.target
 
   if(t.failure) {
-    console.error(padl(10, t.name) + 'FAILED: ' + e.target.failure);
+    console.error(padl(10, t.name) + 'FAILED: ' + e.target.failure)
   } else {
     var result = padl(18, t.name)
       + padr(13, t.hz.toFixed(2) + ' op/s')
       + ' \xb1' + padr(7, t.stats.rme.toFixed(2) + '%')
-      + padr(15, ' (' + t.stats.sample.length + ' samples)');
+      + padr(15, ' (' + t.stats.sample.length + ' samples)')
 
-    console.log(result);
+    console.log(result)
   }
 }
 
 function logStart() {
-  console.log(this.name);
-  console.log('-------------------------------------------------------');
+  console.log(this.name)
+  console.log('-------------------------------------------------------')
 }
 
 function logComplete() {
-  console.log('-------------------------------------------------------');
+  console.log('-------------------------------------------------------')
 }
 
 function runSuite(suite) {
@@ -63,7 +64,7 @@ function runSuite(suite) {
     .on('start', logStart)
     .on('cycle', logResults)
     .on('complete', logComplete)
-    .run();
+    .run()
 }
 
 function mostFromArray (a) {
@@ -108,81 +109,94 @@ class FromArrayTask {
 
 function runMost(deferred, mostPromise) {
   mostPromise.then(function() {
-    deferred.resolve();
+    deferred.resolve()
   }, function(e) {
-    deferred.benchmark.emit({ type: 'error', error: e });
-    deferred.resolve(e);
-  });
+    deferred.benchmark.emit({ type: 'error', error: e })
+    deferred.resolve(e)
+  })
 }
 
 function runRx(deferred, rxStream) {
   rxStream.subscribe({
     onNext: noop,
     onCompleted: function() {
-      deferred.resolve();
+      deferred.resolve()
     },
     onError: function(e) {
-      deferred.benchmark.emit({ type: 'error', error: e });
-      deferred.resolve(e);
+      deferred.benchmark.emit({ type: 'error', error: e })
+      deferred.resolve(e)
     }
-  });
+  })
 }
 
 function runXstream(deferred, xsStream) {
   xsStream.addListener({
     next: noop,
     complete: function() {
-      deferred.resolve();
+      deferred.resolve()
     },
     error: function(e) {
-      deferred.benchmark.emit({ type: 'error', error: e });
-      deferred.resolve(e);
+      deferred.benchmark.emit({ type: 'error', error: e })
+      deferred.resolve(e)
     }
-  });
+  })
+}
+
+function runRx6(deferred, rxStream) {
+  rxStream.subscribe({
+    next: noop,
+    complete: function() {
+      deferred.resolve()
+    },
+    error: function(e) {
+      deferred.benchmark.emit({ type: 'error', error: e })
+      deferred.resolve(e)
+    }
+  })
 }
 
 function runRx5(deferred, rxStream) {
   rxStream.subscribe({
     next: noop,
     complete: function() {
-      deferred.resolve();
+      deferred.resolve()
     },
     error: function(e) {
-      deferred.benchmark.emit({ type: 'error', error: e });
-      deferred.resolve(e);
+      deferred.benchmark.emit({ type: 'error', error: e })
+      deferred.resolve(e)
     }
-  });
+  })
 }
 
 function runKefir(deferred, kefirStream) {
-  kefirStream.onValue(noop);
+  kefirStream.onValue(noop)
   kefirStream.onEnd(function() {
-    deferred.resolve();
-  });
+    deferred.resolve()
+  })
 }
 
 function kefirFromArray(array) {
   return kefir.stream(function(emitter) {
     for(var i=0; i<array.length; ++i) {
-      emitter.emit(array[i]);
+      emitter.emit(array[i])
     }
-    emitter.end();
-  });
+    emitter.end()
+  })
 }
 
 function runBacon(deferred, baconStream) {
   try {
-    baconStream.onValue(noop);
+    baconStream.onValue(noop)
     baconStream.onEnd(function() {
-      deferred.resolve();
-    });
+      deferred.resolve()
+    })
     baconStream.onError(function(e) {
-      deferred.benchmark.emit({ type: 'error', error: e });
-      deferred.resolve(e);
-    });
+      deferred.benchmark.emit({ type: 'error', error: e })
+      deferred.resolve(e)
+    })
   } catch(e) {
-    deferred.benchmark.emit({ type: 'error', error: e });
-    deferred.resolve(e);
+    deferred.benchmark.emit({ type: 'error', error: e })
+    deferred.resolve(e)
   }
 }
 
@@ -192,24 +206,24 @@ function runBacon(deferred, baconStream) {
 function runHighland(deferred, highlandStream) {
   highlandStream.pull(function(err, z) {
     if(err) {
-      deferred.reject(err);
-      return;
+      deferred.reject(err)
+      return
     }
 
-    deferred.resolve(z);
-  });
+    deferred.resolve(z)
+  })
 }
 
 function padl(n, s) {
   while(s.length < n) {
-    s += ' ';
+    s += ' '
   }
-  return s;
+  return s
 }
 
 function padr(n, s) {
   while (s.length < n) {
-    s = ' ' + s;
+    s = ' ' + s
   }
-  return s;
+  return s
 }

--- a/packages/core/test/perf/scan.js
+++ b/packages/core/test/perf/scan.js
@@ -1,63 +1,63 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {scan} = require('../../src/index');
+const Benchmark = require('benchmark')
+const {scan} = require('../../src/index')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs');
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const rx = require('rx')
+const rxjs = require('@reactivex/rxjs')
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000);
-const a = new Array(n);
+const n = runners.getIntArg(1000000)
+const a = new Array(n)
 for(let i = 0; i< a.length; ++i) {
-  a[i] = i;
+  a[i] = i
 }
 
-const suite = Benchmark.Suite('scan -> reduce ' + n + ' integers');
+const suite = Benchmark.Suite('scan -> reduce ' + n + ' integers')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
   .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(passthrough, 0, scan(sum, 0, mostFromArray(a))));
+    runners.runMost(deferred, reduce(passthrough, 0, scan(sum, 0, mostFromArray(a))))
   }, options)
   .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
+    runners.runRx(deferred, rx.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0))
   }, options)
   .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).scan(sum, 0).reduce(passthrough, 0));
+    runners.runRx5(deferred, rxjs.Observable.from(a).scan(sum, 0).reduce(passthrough, 0))
   }, options)
   .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).fold(sum, 0).fold(passthrough, 0).last());
+    runners.runXstream(deferred, xs.fromArray(a).fold(sum, 0).fold(passthrough, 0).last())
   }, options)
   .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last());
+    runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough));
+    runners.runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough))
   }, options)
   .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).scan(0, sum).reduce(0, passthrough));
-  }, options);
+    runners.runHighland(deferred, highland(a).scan(0, sum).reduce(0, passthrough))
+  }, options)
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }
 
 function passthrough(z, x) {
-  return x;
+  return x
 }

--- a/packages/core/test/perf/scan.js
+++ b/packages/core/test/perf/scan.js
@@ -1,63 +1,57 @@
 require('babel-register')
 const Benchmark = require('benchmark')
-const {scan} = require('../../src/index')
-const {reduce} = require('../helper/reduce')
-const rx = require('rx')
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir')
+const { scan } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
 const bacon = require('baconjs')
 const highland = require('highland')
 const xs = require('xstream').default
 
-const runners = require('./runners')
-const kefirFromArray = runners.kefirFromArray
-const mostFromArray = runners.mostFromArray
+const { getIntArg, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon, runHighland } = require('./runners')
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000)
+const n = getIntArg(1000000)
 const a = new Array(n)
-for(let i = 0; i< a.length; ++i) {
+for (let i = 0; i < a.length; ++i) {
   a[i] = i
 }
 
 const suite = Benchmark.Suite('scan -> reduce ' + n + ' integers')
 const options = {
   defer: true,
-  onError: function(e) {
+  onError: function (e) {
     e.currentTarget.failure = e.error
   }
 }
 
 suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(passthrough, 0, scan(sum, 0, mostFromArray(a))))
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(passthrough, 0, scan(sum, 0, mostFromArray(a))))
   }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0))
+  .add('rx 6', function (deferred) {
+    runRx6(deferred, rx.from(a).pipe(rxo.scan(sum, 0)).pipe(rxo.reduce(passthrough, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).scan(sum, 0).reduce(passthrough, 0))
+  .add('xstream', function (deferred) {
+    runXstream(deferred, xs.fromArray(a).fold(sum, 0).fold(passthrough, 0).last())
   }, options)
-  .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).fold(sum, 0).fold(passthrough, 0).last())
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last())
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough))
   }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough))
-  }, options)
-  .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).scan(0, sum).reduce(0, passthrough))
+  .add('highland', function (deferred) {
+    runHighland(deferred, highland(a).scan(0, sum).reduce(0, passthrough))
   }, options)
 
-runners.runSuite(suite)
+runSuite(suite)
 
-function sum(x, y) {
+function sum (x, y) {
   return x + y
 }
 
-function passthrough(z, x) {
+function passthrough (z, x) {
   return x
 }

--- a/packages/core/test/perf/skipRepeats.js
+++ b/packages/core/test/perf/skipRepeats.js
@@ -1,57 +1,57 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {skipRepeats} = require('../../src/index');
+const Benchmark = require('benchmark')
+const {skipRepeats} = require('../../src/index')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs');
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const rx = require('rx')
+const rxjs = require('@reactivex/rxjs')
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
-const xstreamDropRepeats = require('xstream/extra/dropRepeats').default;
+const xstreamDropRepeats = require('xstream/extra/dropRepeats').default
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000);
-const a = new Array(n);
+const n = runners.getIntArg(1000000)
+const a = new Array(n)
 for(let i = 0, j = 0; i< a.length; i+=2, ++j) {
-  a[i] = a[i+1] = j;
+  a[i] = a[i+1] = j
 }
 
-const suite = Benchmark.Suite('skipRepeats -> reduce 2 x ' + n + ' integers');
+const suite = Benchmark.Suite('skipRepeats -> reduce 2 x ' + n + ' integers')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
   .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, skipRepeats(mostFromArray(a))));
+    runners.runMost(deferred, reduce(sum, 0, skipRepeats(mostFromArray(a))))
   }, options)
   .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
+    runners.runRx(deferred, rx.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0))
   }, options)
   .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).distinctUntilChanged().reduce(sum, 0));
+    runners.runRx5(deferred, rxjs.Observable.from(a).distinctUntilChanged().reduce(sum, 0))
   }, options)
   .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).compose(xstreamDropRepeats()).fold(sum, 0).last());
+    runners.runXstream(deferred, xs.fromArray(a).compose(xstreamDropRepeats()).fold(sum, 0).last())
   }, options)
   .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last());
+    runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum));
+    runners.runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum))
   }, options)
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }

--- a/packages/core/test/perf/skipRepeats.js
+++ b/packages/core/test/perf/skipRepeats.js
@@ -1,57 +1,51 @@
 require('babel-register')
 const Benchmark = require('benchmark')
-const {skipRepeats} = require('../../src/index')
-const {reduce} = require('../helper/reduce')
-const rx = require('rx')
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir')
+const { skipRepeats } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
 const bacon = require('baconjs')
-const highland = require('highland')
 const xs = require('xstream').default
 
-const runners = require('./runners')
-const kefirFromArray = runners.kefirFromArray
-const mostFromArray = runners.mostFromArray
+const { getIntArg, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon } = require('./runners')
+
 const xstreamDropRepeats = require('xstream/extra/dropRepeats').default
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000)
+const n = getIntArg(1000000)
 const a = new Array(n)
-for(let i = 0, j = 0; i< a.length; i+=2, ++j) {
-  a[i] = a[i+1] = j
+for (let i = 0, j = 0; i < a.length; i += 2, ++j) {
+  a[i] = a[i + 1] = j
 }
 
 const suite = Benchmark.Suite('skipRepeats -> reduce 2 x ' + n + ' integers')
 const options = {
   defer: true,
-  onError: function(e) {
+  onError: function (e) {
     e.currentTarget.failure = e.error
   }
 }
 
 suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, skipRepeats(mostFromArray(a))))
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(sum, 0, skipRepeats(mostFromArray(a))))
   }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0))
+  .add('rx 6', function (deferred) {
+    runRx6(deferred, rx.from(a).pipe(rxo.distinctUntilChanged()).pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).distinctUntilChanged().reduce(sum, 0))
+  .add('xstream', function (deferred) {
+    runXstream(deferred, xs.fromArray(a).compose(xstreamDropRepeats()).fold(sum, 0).last())
   }, options)
-  .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).compose(xstreamDropRepeats()).fold(sum, 0).last())
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last())
-  }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum))
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum))
   }, options)
 
-runners.runSuite(suite)
+runSuite(suite)
 
-function sum(x, y) {
+function sum (x, y) {
   return x + y
 }

--- a/packages/core/test/perf/slice.js
+++ b/packages/core/test/perf/slice.js
@@ -1,71 +1,71 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {skip, take} = require('../../src/index');
+const Benchmark = require('benchmark')
+const {skip, take} = require('../../src/index')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
+const rx = require('rx')
 const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
-const xs = require('xstream').default;
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000);
-const a = new Array(n);
+const n = runners.getIntArg(1000000)
+const a = new Array(n)
 for(let i = 0; i< a.length; ++i) {
-  a[i] = i;
+  a[i] = i
 }
 
-const suite = Benchmark.Suite('skip(n/4) -> take(n/2) ' + n + ' integers');
+const suite = Benchmark.Suite('skip(n/4) -> take(n/2) ' + n + ' integers')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
-const s = n * 0.25;
-const t = n * 0.5;
+const s = n * 0.25
+const t = n * 0.5
 
 suite
   .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, take(t, skip(s, mostFromArray(a)))));
+    runners.runMost(deferred, reduce(sum, 0, take(t, skip(s, mostFromArray(a)))))
   }, options)
   .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).skip(s).take(t).reduce(sum, 0));
+    runners.runRx(deferred, rx.Observable.fromArray(a).skip(s).take(t).reduce(sum, 0))
   }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred,
-      rxjs.Observable.from(a).skip(s).take(t).reduce(sum, 0));
+      rxjs.Observable.from(a).skip(s).take(t).reduce(sum, 0))
   }, options)
   .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).drop(s).take(t).fold(sum, 0).last());
+    runners.runXstream(deferred, xs.fromArray(a).drop(s).take(t).fold(sum, 0).last())
   }, options)
   .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).skip(s).take(t).scan(sum, 0).last());
+    runners.runKefir(deferred, kefirFromArray(a).skip(s).take(t).scan(sum, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).skip(s).take(t).reduce(0, sum));
+    runners.runBacon(deferred, bacon.fromArray(a).skip(s).take(t).reduce(0, sum))
   }, options)
   .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).drop(s).take(t).reduce(0, sum));
+    runners.runHighland(deferred, highland(a).drop(s).take(t).reduce(0, sum))
   }, options)
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function add1(x) {
-  return x + 1;
+  return x + 1
 }
 
 function even(x) {
-  return x % 2 === 0;
+  return x % 2 === 0
 }
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }

--- a/packages/core/test/perf/slice.js
+++ b/packages/core/test/perf/slice.js
@@ -1,30 +1,27 @@
 require('babel-register')
 const Benchmark = require('benchmark')
-const {skip, take} = require('../../src/index')
-const {reduce} = require('../helper/reduce')
-const rx = require('rx')
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir')
+const { skip, take } = require('../../src/index')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
 const bacon = require('baconjs')
 const highland = require('highland')
 const xs = require('xstream').default
 
-const runners = require('./runners')
-const kefirFromArray = runners.kefirFromArray
-const mostFromArray = runners.mostFromArray
+const { getIntArg, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runXstream, runKefir, runBacon, runHighland } = require('./runners')
 
 // Create a stream from an Array of n integers
 // filter out odds, map remaining evens by adding 1, then reduce by summing
-const n = runners.getIntArg(1000000)
+const n = getIntArg(1000000)
 const a = new Array(n)
-for(let i = 0; i< a.length; ++i) {
+for (let i = 0; i < a.length; ++i) {
   a[i] = i
 }
 
 const suite = Benchmark.Suite('skip(n/4) -> take(n/2) ' + n + ' integers')
 const options = {
   defer: true,
-  onError: function(e) {
+  onError: function (e) {
     e.currentTarget.failure = e.error
   }
 }
@@ -33,39 +30,28 @@ const s = n * 0.25
 const t = n * 0.5
 
 suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, take(t, skip(s, mostFromArray(a)))))
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(sum, 0, take(t, skip(s, mostFromArray(a)))))
   }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).skip(s).take(t).reduce(sum, 0))
+  .add('rx 6', function (deferred) {
+    runRx6(deferred,
+      rx.from(a).pipe(rxo.skip(s)).pipe(rxo.take(t)).pipe(rxo.reduce(sum, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred,
-      rxjs.Observable.from(a).skip(s).take(t).reduce(sum, 0))
+  .add('xstream', function (deferred) {
+    runXstream(deferred, xs.fromArray(a).drop(s).take(t).fold(sum, 0).last())
   }, options)
-  .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).drop(s).take(t).fold(sum, 0).last())
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).skip(s).take(t).scan(sum, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).skip(s).take(t).scan(sum, 0).last())
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.fromArray(a).skip(s).take(t).reduce(0, sum))
   }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).skip(s).take(t).reduce(0, sum))
-  }, options)
-  .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).drop(s).take(t).reduce(0, sum))
+  .add('highland', function (deferred) {
+    runHighland(deferred, highland(a).drop(s).take(t).reduce(0, sum))
   }, options)
 
-runners.runSuite(suite)
+runSuite(suite)
 
-function add1(x) {
-  return x + 1
-}
-
-function even(x) {
-  return x % 2 === 0
-}
-
-function sum(x, y) {
+function sum (x, y) {
   return x + y
 }

--- a/packages/core/test/perf/switch.js
+++ b/packages/core/test/perf/switch.js
@@ -1,17 +1,17 @@
 require('babel-register')
-const Benchmark = require('benchmark');
-const {map, switchLatest} = require('../../src/index');
+const Benchmark = require('benchmark')
+const {map, switchLatest} = require('../../src/index')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
+const rx = require('rx')
 const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const lodash = require('lodash');
-const highland = require('highland');
-const xs = require('xstream').default;
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const lodash = require('lodash')
+const highland = require('highland')
+const xs = require('xstream').default
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
 
 // Switching n streams, each containing m items.
@@ -19,36 +19,36 @@ const mostFromArray = runners.mostFromArray
 // behaving like concatMap, but gives a sense of the
 // relative overhead introduced by each lib's switching
 // combinator.
-const mn = runners.getIntArg2(10000, 1000);
-const a = build(mn[0], mn[1]);
+const mn = runners.getIntArg2(10000, 1000)
+const a = build(mn[0], mn[1])
 
 function build(m, n) {
-  const a = new Array(n);
+  const a = new Array(n)
   for(let i = 0; i< a.length; ++i) {
-    a[i] = buildArray(i*1000, m);
+    a[i] = buildArray(i*1000, m)
   }
-  return a;
+  return a
 }
 
 function buildArray(base, n) {
-  const a = new Array(n);
+  const a = new Array(n)
   for(let i = 0; i< a.length; ++i) {
-    a[i] = base + i;
+    a[i] = base + i
   }
-  return a;
+  return a
 }
 
-const suite = Benchmark.Suite('switch ' + mn[0] + ' x ' + mn[1] + ' streams');
+const suite = Benchmark.Suite('switch ' + mn[0] + ' x ' + mn[1] + ' streams')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
   .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(sum, 0, switchLatest(map(mostFromArray, mostFromArray(a)))));
+    runners.runMost(deferred, reduce(sum, 0, switchLatest(map(mostFromArray, mostFromArray(a)))))
   }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred,
@@ -58,28 +58,28 @@ suite
   .add('rx 4', function(deferred) {
     runners.runRx(deferred,
       rx.Observable.fromArray(a).flatMapLatest(
-        function(x) {return rx.Observable.fromArray(x)}).reduce(sum, 0));
+        function(x) {return rx.Observable.fromArray(x)}).reduce(sum, 0))
   }, options)
   .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).map(xs.fromArray).flatten().fold(sum, 0).last());
+    runners.runXstream(deferred, xs.fromArray(a).map(xs.fromArray).flatten().fold(sum, 0).last())
   }, options)
   .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).flatMapLatest(kefirFromArray).scan(sum, 0).last());
+    runners.runKefir(deferred, kefirFromArray(a).flatMapLatest(kefirFromArray).scan(sum, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.fromArray(a).flatMapLatest(bacon.fromArray).reduce(0, sum));
+    runners.runBacon(deferred, bacon.fromArray(a).flatMapLatest(bacon.fromArray).reduce(0, sum))
   }, options)
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function sum(x, y) {
-  return x + y;
+  return x + y
 }
 
 function even(x) {
-  return x % 2 === 0;
+  return x % 2 === 0
 }
 
 function identity(x) {
-  return x;
+  return x
 }

--- a/packages/core/test/perf/zip.js
+++ b/packages/core/test/perf/zip.js
@@ -1,22 +1,20 @@
 const Benchmark = require('benchmark')
-const {zip} = require('../../src')
-const {reduce} = require('../helper/reduce')
-const rx = require('rx')
-const rxjs = require('@reactivex/rxjs')
-const kefir = require('kefir')
+const { zip } = require('../../src')
+const { reduce } = require('../helper/reduce')
+const rx = require('rxjs')
+const rxo = require('rxjs/operators')
 const bacon = require('baconjs')
 const highland = require('highland')
 
-const runners = require('./runners')
-const kefirFromArray = runners.kefirFromArray
-const mostFromArray = runners.mostFromArray
+const { getIntArg, runSuite, kefirFromArray, mostFromArray, runMost, runRx6, runKefir, runBacon, runHighland } = require('./runners')
+
 // Create 2 streams, each with n items, zip them by summing the
 // corresponding index pairs, then reduce the resulting stream by summing
-const n = runners.getIntArg(100000)
+const n = getIntArg(100000)
 const a = new Array(n)
 const b = new Array(n)
 
-for(let i = 0; i<n; ++i) {
+for (let i = 0; i < n; ++i) {
   a[i] = i
   b[i] = i
 }
@@ -24,37 +22,35 @@ for(let i = 0; i<n; ++i) {
 const suite = Benchmark.Suite('zip 2 x ' + n + ' integers')
 const options = {
   defer: true,
-  onError: function(e) {
+  onError: function (e) {
     e.currentTarget.failure = e.error
   }
 }
 
 suite
-  .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(add, 0, zip(add, mostFromArray(b), mostFromArray(a))))
+  .add('most', function (deferred) {
+    runMost(deferred, reduce(add, 0, zip(add, mostFromArray(a), mostFromArray(b))))
   }, options)
-  .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).zip(rx.Observable.fromArray(b), add).reduce(add, 0))
+  .add('rx 6', function (deferred) {
+    runRx6(deferred, rx.from(a).pipe(rxo.zip(rx.from(b), add)).pipe(rxo.reduce(add, 0)))
   }, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).zip(rxjs.Observable.from(b), add).reduce(add, 0))
+  .add('kefir', function (deferred) {
+    runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last())
   }, options)
-  .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last())
+  .add('bacon', function (deferred) {
+    runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add))
   }, options)
-  .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add))
-  }, options)
-  .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).zip(highland(b)).map(addPair).reduce(0, add))
+  .add('highland', function (deferred) {
+    runHighland(deferred, highland(a).zip(highland(b)).map(addPair).reduce(0, add))
   }, options)
   // There is no zip in xstream
 
-runners.runSuite(suite)
+runSuite(suite)
 
-function addPair(pair) {
+function addPair (pair) {
   return pair[0] + pair[1]
 }
-function add(a, b) {
+
+function add (a, b) {
   return a + b
 }

--- a/packages/core/test/perf/zip.js
+++ b/packages/core/test/perf/zip.js
@@ -1,60 +1,60 @@
-const Benchmark = require('benchmark');
-const {zip} = require('../../src');
+const Benchmark = require('benchmark')
+const {zip} = require('../../src')
 const {reduce} = require('../helper/reduce')
-const rx = require('rx');
-const rxjs = require('@reactivex/rxjs');
-const kefir = require('kefir');
-const bacon = require('baconjs');
-const highland = require('highland');
+const rx = require('rx')
+const rxjs = require('@reactivex/rxjs')
+const kefir = require('kefir')
+const bacon = require('baconjs')
+const highland = require('highland')
 
-const runners = require('./runners');
-const kefirFromArray = runners.kefirFromArray;
+const runners = require('./runners')
+const kefirFromArray = runners.kefirFromArray
 const mostFromArray = runners.mostFromArray
 // Create 2 streams, each with n items, zip them by summing the
 // corresponding index pairs, then reduce the resulting stream by summing
-const n = runners.getIntArg(100000);
-const a = new Array(n);
-const b = new Array(n);
+const n = runners.getIntArg(100000)
+const a = new Array(n)
+const b = new Array(n)
 
 for(let i = 0; i<n; ++i) {
-  a[i] = i;
-  b[i] = i;
+  a[i] = i
+  b[i] = i
 }
 
-const suite = Benchmark.Suite('zip 2 x ' + n + ' integers');
+const suite = Benchmark.Suite('zip 2 x ' + n + ' integers')
 const options = {
   defer: true,
   onError: function(e) {
-    e.currentTarget.failure = e.error;
+    e.currentTarget.failure = e.error
   }
-};
+}
 
 suite
   .add('most', function(deferred) {
-    runners.runMost(deferred, reduce(add, 0, zip(add, mostFromArray(b), mostFromArray(a))));
+    runners.runMost(deferred, reduce(add, 0, zip(add, mostFromArray(b), mostFromArray(a))))
   }, options)
   .add('rx 4', function(deferred) {
-    runners.runRx(deferred, rx.Observable.fromArray(a).zip(rx.Observable.fromArray(b), add).reduce(add, 0));
+    runners.runRx(deferred, rx.Observable.fromArray(a).zip(rx.Observable.fromArray(b), add).reduce(add, 0))
   }, options)
   .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.from(a).zip(rxjs.Observable.from(b), add).reduce(add, 0));
+    runners.runRx5(deferred, rxjs.Observable.from(a).zip(rxjs.Observable.from(b), add).reduce(add, 0))
   }, options)
   .add('kefir', function(deferred) {
-    runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last());
+    runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last())
   }, options)
   .add('bacon', function(deferred) {
-    runners.runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add));
+    runners.runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add))
   }, options)
   .add('highland', function(deferred) {
-    runners.runHighland(deferred, highland(a).zip(highland(b)).map(addPair).reduce(0, add));
+    runners.runHighland(deferred, highland(a).zip(highland(b)).map(addPair).reduce(0, add))
   }, options)
   // There is no zip in xstream
 
-runners.runSuite(suite);
+runners.runSuite(suite)
 
 function addPair(pair) {
-  return pair[0] + pair[1];
+  return pair[0] + pair[1]
 }
 function add(a, b) {
-  return a + b;
+  return a + b
 }


### PR DESCRIPTION
* Add RxJS 6 using recommended `pipe` coding style.
* Remove RxJS 4 and 5.
* Update perf test code style to align more closely with the rest of the repo (still not fully aligned, tho).
