### PR TITLE
feat(core): support refinements in filter operator

### DIFF
--- a/packages/core/type-definitions/combinator/filter.d.ts
+++ b/packages/core/type-definitions/combinator/filter.d.ts
@@ -1,6 +1,8 @@
 import { Stream } from '@most/types';
 
+export function filter<A, B extends A>(p: (a: A) => a is B, s: Stream<A>): Stream<B>;
 export function filter<A>(p: (a: A) => boolean, s: Stream<A>): Stream<A>;
+export function filter<A, B extends A>(p: (a: A) => a is B): (s: Stream<A>) => Stream<B>;
 export function filter<A>(p: (a: A) => boolean): (s: Stream<A>) => Stream<A>;
 
 export function skipRepeats<A>(s: Stream<A>): Stream<A>;


### PR DESCRIPTION
Hi, this PR adds support for type refinements in filter operator:
```typescript
type Foo = { foo: string }
const isFoo = (obj: any): obj is Foo => typeof obj['foo'] === 'string';
declare const source: Stream<unknown>;
const foo = filter(isFoo)(source) // Stream<Foo>
```