### PR TITLE
Fix sinon spy function type

### DIFF
--- a/packages/disposable/test/disposeAll-test.ts
+++ b/packages/disposable/test/disposeAll-test.ts
@@ -9,7 +9,7 @@ const noop = (): void => {}
 interface DisposableSpy {
   dispose: SinonSpy
 }
-const disposableSpy = (f: Function): DisposableSpy => ({
+const disposableSpy = (f: () => any): DisposableSpy => ({
   dispose: spy(f)
 })
 


### PR DESCRIPTION
This should fix the error in https://github.com/mostjs/core/pull/313 by being forward compatible with sinon 7.5.1.  It's also compatible with the version on current master.