### PR TITLE
Allow union return type for recoverWith and continueWith

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -349,7 +349,7 @@ continueWith
 
 .. code-block:: haskell
 
-  continueWith :: (() -> Stream a) -> Stream a -> Stream a
+  continueWith :: (() -> Stream b) -> Stream a -> Stream (a | b)
 
 Replace the end of a :ref:`Stream` with another :ref:`Stream`. ::
 
@@ -1165,7 +1165,7 @@ recoverWith
 
 .. code-block:: haskell
 
-  recoverWith :: (Error -> Stream a) -> Stream a -> Stream a
+  recoverWith :: (Error -> Stream b) -> Stream a -> Stream (a | b)
 
 Recover from a stream failure by calling a function to create a new :ref:`Stream`. ::
 

--- a/packages/core/src/combinator/continueWith.ts
+++ b/packages/core/src/combinator/continueWith.ts
@@ -8,7 +8,7 @@ import { withLocalTime } from './withLocalTime'
 import { disposeOnce, tryDispose } from '@most/disposable'
 import { Stream, Scheduler, Time, Disposable, Sink } from '@most/types'
 
-export const continueWith = <A, B>(f: () => Stream<B>, stream: Stream<A>): Stream<A | B> =>
+export const continueWith = <A, B = A>(f: () => Stream<B>, stream: Stream<A>): Stream<A | B> =>
   new ContinueWith(f, stream)
 
 class ContinueWith<A, B> implements Stream<A | B> {

--- a/packages/core/src/combinator/errors.ts
+++ b/packages/core/src/combinator/errors.ts
@@ -43,7 +43,7 @@ class ErrorStream implements Stream<never> {
   }
 }
 
-class RecoverWith<A, B, E extends Error> implements Stream<A | B> {
+class RecoverWith<A, E extends Error, B> implements Stream<A | B> {
   private readonly f: (error: E) => Stream<B>;
   private readonly source: Stream<A>;
 
@@ -57,7 +57,7 @@ class RecoverWith<A, B, E extends Error> implements Stream<A | B> {
   }
 }
 
-class RecoverWithSink<A, B, E extends Error> implements Sink<A>, Disposable {
+class RecoverWithSink<A, E extends Error, B> implements Sink<A>, Disposable {
   private readonly f: (error: E) => Stream<B>
   private readonly sink: SafeSink<A>
   private readonly scheduler: Scheduler

--- a/packages/core/src/combinator/errors.ts
+++ b/packages/core/src/combinator/errors.ts
@@ -19,7 +19,7 @@ import { Stream, Sink, Scheduler, Disposable, Time } from '@most/types'
  * @param stream
  * @returns new stream which will recover from an error by calling f
  */
-export const recoverWith = <A, B, E extends Error>(f: (error: E) => Stream<B>, stream: Stream<A>): Stream<A | B> =>
+export const recoverWith = <A, E extends Error, B = A>(f: (error: E) => Stream<B>, stream: Stream<A>): Stream<A | B> =>
   isCanonicalEmpty(stream) ? empty()
     : new RecoverWith(f, stream)
 

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -187,8 +187,8 @@ declare export function debounce <A> (period: Period): (s: Stream<A>) => Stream<
 declare export function fromPromise <A> (pa: Promise<A>): Stream<A>
 declare export function awaitPromises <A> (spa: Stream<Promise<A>>): Stream<A>
 
-declare export function recoverWith <A, B, E:Error> (f: (E) => Stream<B>, s: Stream<A>): Stream<A | B>
-declare export function recoverWith <A, B, E:Error> (f: (E) => Stream<B>): (s: Stream<A>) => Stream<A | B>
+declare export function recoverWith <A, E:Error, B = A> (f: (E) => Stream<B>, s: Stream<A>): Stream<A | B>
+declare export function recoverWith <A, E:Error, B = A> (f: (E) => Stream<B>): (s: Stream<A>) => Stream<A | B>
 
 declare export function throwError <E:Error> (e: Error): Stream<any>
 

--- a/packages/core/src/index.js.flow
+++ b/packages/core/src/index.js.flow
@@ -70,8 +70,8 @@ declare export function mergeMapConcurrently <A, B> (f: (A) => Stream<B>): {
   (concurrency: number): (s: Stream<A>) => Stream<B>
 }
 
-declare export function continueWith <A> (f: (any) => Stream<A>, s: Stream<A>): Stream<A>
-declare export function continueWith <A> (f: (any) => Stream<A>): (s: Stream<A>) => Stream<A>
+declare export function continueWith <A, B> (f: (any) => Stream<B>, s: Stream<A>): Stream<A | B>
+declare export function continueWith <A, B> (f: (any) => Stream<B>): (s: Stream<A>) => Stream<A | B>
 
 declare export function switchLatest <A> (s: Stream<Stream<A>>): Stream<A>
 
@@ -187,8 +187,8 @@ declare export function debounce <A> (period: Period): (s: Stream<A>) => Stream<
 declare export function fromPromise <A> (pa: Promise<A>): Stream<A>
 declare export function awaitPromises <A> (spa: Stream<Promise<A>>): Stream<A>
 
-declare export function recoverWith <A, E:Error> (f: (E) => Stream<A>, s: Stream<A>): Stream<A>
-declare export function recoverWith <A, E:Error> (f: (E) => Stream<A>): (s: Stream<A>) => Stream<A>
+declare export function recoverWith <A, B, E:Error> (f: (E) => Stream<B>, s: Stream<A>): Stream<A | B>
+declare export function recoverWith <A, B, E:Error> (f: (E) => Stream<B>): (s: Stream<A>) => Stream<A | B>
 
 declare export function throwError <E:Error> (e: Error): Stream<any>
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,8 +107,8 @@ export { join }
 
 import { continueWith as _continueWith } from './combinator/continueWith'
 interface ContinueWith {
-  <A>(f: () => Stream<A>, s: Stream<A>): Stream<A>
-  <A>(f: () => Stream<A>): (s: Stream<A>) => Stream<A>
+  <A, B = A>(f: () => Stream<B>, s: Stream<A>): Stream<A | B>
+  <A, B = A>(f: () => Stream<B>): (s: Stream<A>) => Stream<A | B>
 }
 export const continueWith: ContinueWith = curry2(_continueWith)
 
@@ -331,8 +331,8 @@ export { fromPromise, awaitPromises } from './combinator/promises'
 import { recoverWith as _recoverWith, throwError } from './combinator/errors'
 
 interface RecoverWith {
-  <A, E extends Error>(p: (error: E) => Stream<A>, s: Stream<A>): Stream<A>
-  <A, E extends Error>(p: (error: E) => Stream<A>): (s: Stream<A>) => Stream<A>
+  <A, E extends Error, B = A>(p: (error: E) => Stream<B>, s: Stream<A>): Stream<A | B>
+  <A, E extends Error, B = A>(p: (error: E) => Stream<B>): (s: Stream<A>) => Stream<A | B>
 }
 export const recoverWith: RecoverWith = curry2(_recoverWith)
 export { throwError }

--- a/packages/core/test/combinator/continueWith-test.ts
+++ b/packages/core/test/combinator/continueWith-test.ts
@@ -1,14 +1,23 @@
 import { describe, it } from 'mocha'
-import { is, fail } from '@briancavalier/assert'
+import { is, fail, eq } from '@briancavalier/assert'
 
 import { continueWith } from '../../src/combinator/continueWith'
 import { drain } from '../helper/observe'
 import { now } from '../../src/source/now'
+import { collectEventsFor, Event } from '../helper/testEnv'
 
 describe('continueWith', () => {
   it('when f throws, should propagate error', () => {
     const error = new Error()
     const s = continueWith(() => { throw error }, now(0))
     return drain(s).then(fail, is(error))
+  })
+
+  it('should allow union type', () => {
+    const s = continueWith(() => now('456'), now(123))
+    return collectEventsFor(1, s).then(eq([
+      { time: 0, value: 123 },
+      { time: 0, value: '456' }
+    ] as Event<string | number>[]))
   })
 })

--- a/packages/core/test/combinator/errors-test.ts
+++ b/packages/core/test/combinator/errors-test.ts
@@ -32,6 +32,11 @@ describe('recoverWith', () => {
     return observe(eq(sentinel), s)
   })
 
+  it('should allow union type', () => {
+    const s = recoverWith(() => now('456'), now(123))
+    return observe(eq(123), s)
+  })
+
   it('should recover from errors before recoverWith', () => {
     const s = map(() => {
       throw new Error()


### PR DESCRIPTION
This ports https://github.com/cujojs/most/pull/531 to `@most/core`, and extends it to cover `continueWith` as well.

Specifically looking for feedback on the `continueWith` change before I proceed with tests and docs.

### Todo

- [x] type and/or unit tests
- [x] docs