### PR TITLE
zipArray, combineArray - Support Literal & Dynamic array type

### DIFF
--- a/packages/core/src/combinator/combine.ts
+++ b/packages/core/src/combinator/combine.ts
@@ -7,7 +7,7 @@ import { IndexSink, IndexedValue } from '../sink/IndexSink'
 import { disposeAll, tryDispose } from '@most/disposable'
 import invoke from '../invoke'
 import { Stream, Sink, Scheduler, Disposable, Time } from '@most/types'
-import { ToStreamsArray } from './variadic'
+import { InputStreamArray } from './variadic'
 
 /**
  * Combine latest events from two streams
@@ -27,16 +27,16 @@ export const combine = <A, B, C>(f: (a: A, b: B) => C, stream1: Stream<A>, strea
 * @returns stream containing the result of applying f to the most recent
 *  event of each input stream, whenever a new event arrives on any stream.
 */
-export const combineArray = <Args extends unknown[], R>(f: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R> =>
+export const combineArray = <Args extends unknown[], R>(f: (...args: Args) => R, streams: InputStreamArray<Args>): Stream<R> =>
   streams.length === 0 || containsCanonicalEmpty(streams) ? empty()
     : streams.length === 1 ? map(f as any, streams[0])
-      : new Combine(f, streams)
+      : new Combine(f, streams as Stream<Args>[])
 
 class Combine<Args extends unknown[], B> implements Stream<B> {
   private readonly f: (...args: Args) => B
-  private readonly sources: ToStreamsArray<Args>;
+  private readonly sources: Stream<Args>[];
 
-  constructor(f: (...args: Args) => B, sources: ToStreamsArray<Args>) {
+  constructor(f: (...args: Args) => B, sources: Stream<Args>[]) {
     this.f = f
     this.sources = sources
   }

--- a/packages/core/src/combinator/variadic.ts
+++ b/packages/core/src/combinator/variadic.ts
@@ -1,9 +1,7 @@
 import { Stream } from '@most/types'
 
-// Map arrays to arrays of Streams:
-// Array<A> => Array<Stream<A>>
-// [A, B, C, ...] => [Stream<A>, Stream<B>, Stream<C>, ...]
-// TODO: use readonly any[] once TS 3.4.x has been in the wild for "enough" time
-export type ToStreamsArray<A extends ArrayLike<any>> = {
+type LiteralArray<A extends ArrayLike<any>> = {
   [K in keyof A]: Stream<A[K]>
 }
+
+export type InputStreamArray<Args extends ArrayLike<any>> = Readonly<LiteralArray<Args> | Stream<unknown>[]>

--- a/packages/core/src/combinator/zip.ts
+++ b/packages/core/src/combinator/zip.ts
@@ -9,7 +9,7 @@ import { map as mapArray } from '@most/prelude'
 import invoke from '../invoke'
 import Queue from '../Queue'
 import { Stream, Sink, Scheduler, Disposable, Time } from '@most/types'
-import { ToStreamsArray } from './variadic'
+import { InputStreamArray } from './variadic'
 
 interface NonEmptyQueue<A> extends Queue<A> {
   shift(): A
@@ -35,7 +35,7 @@ export function zip <A, B, R>(f: (a: A, b: B) => R, stream1: Stream<A>, stream2:
 * @returns {Stream} new stream with items at corresponding indices combined
 *  using f
 */
-export const zipArray = <Args extends unknown[], R>(f: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R> =>
+export const zipArray = <Args extends readonly unknown[], R>(f: (...args: Args) => R, streams: InputStreamArray<Args>): Stream<R> =>
   streams.length === 0 || containsCanonicalEmpty(streams) ? empty()
     : streams.length === 1 ? map(f as any, streams[0])
       : new Zip(f as any, streams)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,8 +160,8 @@ interface Combine {
 }
 export const combine: Combine = curry3(_combine)
 interface CombineArray {
-  <Args extends unknown[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>
-  <Args extends unknown[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>
+  <Args extends readonly unknown[], R>(fn: (...args: Args) => R, streams: InputStreamArray<Args>): Stream<R>
+  <Args extends readonly unknown[], R>(fn: (...args: Args) => R): (streams: InputStreamArray<Args>) => Stream<R>
 }
 export const combineArray: CombineArray = curry2(_combineArray as any) as any
 
@@ -206,8 +206,8 @@ interface Zip {
 }
 export const zip: Zip = curry3(_zip)
 interface ZipArray {
-  <Args extends unknown[], R>(fn: (...args: Args) => R, streams: ToStreamsArray<Args>): Stream<R>
-  <Args extends unknown[], R>(fn: (...args: Args) => R): (streams: ToStreamsArray<Args>) => Stream<R>
+  <Args extends readonly unknown[], R>(fn: (...args: Args) => R, streams: InputStreamArray<Args>): Stream<R>
+  <Args extends readonly unknown[], R>(fn: (...args: Args) => R): (streams: InputStreamArray<Args>) => Stream<R>
 }
 export const zipArray: ZipArray = curry2(_zipArray as any) as any
 
@@ -352,7 +352,7 @@ import {
   PropagateTask as PropagateTaskResult
 } from './scheduler/PropagateTask'
 import { Stream, Sink, Scheduler, Disposable, Time } from '@most/types'
-import { ToStreamsArray } from './combinator/variadic'
+import { InputStreamArray } from './combinator/variadic'
 
 interface PropagateTask {
   <A>(run: PropagateTaskRun<A>, value: A, sink: Sink<A>): PropagateTaskResult

--- a/packages/core/test/combine-test.ts
+++ b/packages/core/test/combine-test.ts
@@ -10,7 +10,7 @@ import { collectEventsFor, makeEvents, makeEventsFromArray } from './helper/test
 
 const sentinel = { value: 'sentinel' }
 
-const args = <Args extends unknown[]>(...args: Args): Args => args
+const args = <Args extends readonly unknown[]>(...args: Args): Args => args
 
 describe('combine', function () {
   it('given one canonical empty stream, should return canonical empty', () => {


### PR DESCRIPTION
Hey everyone

Currently, we don't support either dynamic or literal types. current version of `@most/core 1.6.1` outputs the following error for both usages

```typescript
const newLocal = [now(22), now('ee')]
const combineTest = combineArray((scale, drag) => ({ transform: `scale(${scale})` }), newLocal);

/**
Argument of type '(Stream<string> | Stream<number> | Stream<null>)[]' is not assignable to parameter of type 'readonly [a: Stream<string | number | null>, b: Stream<string | number | null>]'.
  Target requires 2 element(s) but source may have fewer.ts(2345)
*/

````


I've made the following tests in both versions of typescript `^3.5.2` and `4.0.3`, they seem to output the same results
``` typescript
const dynamic = [now(1), now('a'), now(null)]                    // (Stream<number> | Stream<string> | Stream<null>)[]
const readonlyLiteral = [now(1), now('a'), now(null)] as const   // readonly [Stream<number>, Stream<string>, Stream<null>]
const literal = [now(1), now('a'), now(null)] as [Stream<number>, Stream<string>, Stream<null>]

combineArray((a, b) => a, dynamic) // a: string | number | null, b: string | number | null
combineArray((a, b) => a, readonlyLiteral) // a: number, b: string 
combineArray((a, b) => a, literal) // a: number, b: string 
combineArray((a) => a, []) // a: unknown

zipArray((a, b) => null, dynamic) // a: string | number | null, b: string | number | null
zipArray((a, b) => null, readonlyLiteral) // a: number, b: string 
zipArray((a, b) => null, literal) // a: number, b: string 
zipArray((a) => null, []) // a: unknown

```


I hope this resolves all use cases, please check PR and let me know if i didn't miss anything