### PR TITLE
[Maybe Bugfix] Change awaitPromises/fromPromise not to emit events after disposed

### DIFF
--- a/packages/core/test/combinator/promises-test.ts
+++ b/packages/core/test/combinator/promises-test.ts
@@ -4,6 +4,8 @@ import { assert, is, eq } from '@briancavalier/assert'
 import { awaitPromises, fromPromise } from '../../src/combinator/promises'
 import { recoverWith } from '../../src/combinator/errors'
 import { empty, isCanonicalEmpty } from '../../src/source/empty'
+import { switchLatest } from '../../src/combinator/switch'
+import { map } from '../../src/combinator/transform'
 
 import { atTime, makeEventsFromArray, collectEventsFor } from '../helper/testEnv'
 
@@ -82,6 +84,18 @@ describe('promises', () => {
 
       return collectEventsFor(1, s)
         .then(eq([{ time: 1, value: sentinel }]))
+    })
+
+    it('should stop emitting after disposed', function () {
+      const s = switchLatest(map(
+        v => fromPromise(new Promise(resolve => setTimeout(() => resolve(v), 10))),
+        makeEventsFromArray(1, [1, 2])
+      ))
+      return collectEventsFor(10, s)
+        .then(events => {
+          eq(2, events[0].value)
+          eq(1, events.length)
+        })
     })
   })
 })


### PR DESCRIPTION
Hi! It's been a while since I last made a little contribution to this project.
I'm very surprised that this whole project migrated to TypeScript, which is great! 🎉 

---

I found an edge case where awaitPromises/fromPromise unexpectedly emit events after disposed.
The case may occur when you use switchLatest with slow resolving Promise.

I added a test case, which fails before this modification, and passes after this.
I find managing `disposed` flag inside AwaitSink a bit awkward... but could not make it in another way, since Promise is not cancellable.

---

Anyway, thanks for maintaining this precious project. 🙏 