### PR TITLE
fixes CI build, some remarks for installing deps in local repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: Install Local JavaScript Dependencies
           command: |
             nvm use default
-            npm install
+            npm install --legacy-peer-deps
 
       # Store a cache of local JavaScript modules.
       - save_cache:
@@ -111,7 +111,7 @@ jobs:
           name: Install Local JavaScript Dependencies
           command: |
             nvm use node
-            npm install
+            npm install --legacy-peer-deps
 
       # Store a cache of local JavaScript modules.
       - save_cache:
@@ -132,13 +132,13 @@ workflows:
     jobs:
       - Test-LTS
       # filters:
-      #   # Define rules to allow/block exeution of specific branches.
+      #   # Define rules to allow/block execution of specific branches.
       #   branches:
       #     only:
       #       - master
       - Test-Latest
         # filters:
-        #   # Define rules to allow/block exeution of specific branches.
+        #   # Define rules to allow/block execution of specific branches.
         #   branches:
         #     only:
         #       - master

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Specifically, `@most/core` features Most's battle-tested, high-performance archi
 * [API docs](https://mostcore.readthedocs.io)
 * [Get it](#get-it)
 * [Examples](examples)
+* [Contribute](#contribute)
 
 ## Get it
 
@@ -25,4 +26,18 @@ Specifically, `@most/core` features Most's battle-tested, high-performance archi
 npm install --save @most/core @most/scheduler
 
 yarn add @most/core @most/scheduler
+```
+
+## Contribute
+
+After cloning the repository
+
+```
+npm install --legacy-peer-deps
+```
+
+### Running the Tests
+
+```
+npm test
 ```


### PR DESCRIPTION
Just a workaround adding `--legacy-peer-deps`.

Actually, I have really no idea why npm complains that some dependencies in the monorepo do no longer fit together… 