### PR TITLE
Strawman proposal for providing Fantasyland Stream type in a separate package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: Install Local JavaScript Dependencies
           command: |
             nvm use default
-            npm install
+            npm install --legacy-peer-deps
 
       # Store a cache of local JavaScript modules.
       - save_cache:
@@ -111,7 +111,7 @@ jobs:
           name: Install Local JavaScript Dependencies
           command: |
             nvm use node
-            npm install
+            npm install --legacy-peer-deps
 
       # Store a cache of local JavaScript modules.
       - save_cache:

--- a/packages/core-fl/.eslintignore
+++ b/packages/core-fl/.eslintignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+.idea/
+examples/
+benchmark/
+experiments/
+perf/
+test/perf/
+dist/

--- a/packages/core-fl/package.json
+++ b/packages/core-fl/package.json
@@ -1,0 +1,41 @@
+{
+  "author": "seemann@visisoft.de",
+  "description": "Fantasy-Land Api for @most/core",
+  "exports": {
+    ".": {
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "type-definitions",
+    "dist"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "name": "@most/core-fl",
+  "scripts": {
+    "build:dist": "rollup -c",
+    "test": "mocha --require ts-node/register"
+  },
+  "type": "module",
+  "version": "1.0.0",
+  "dependencies": {
+    "@most/disposable": "^1.3.0",
+    "@most/prelude": "^1.8.0",
+    "@most/scheduler": "^1.3.0",
+    "@most/types": "^1.1.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@types/ramda": "^0.29.10",
+    "fp-ts": "^2.16.2",
+    "mocha": "^10.3.0",
+    "ramda": "^0.29.1",
+    "rollup": "^4.10.0",
+    "rollup-plugin-typescript2": "^0.36.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/core-fl/rollup.config.js
+++ b/packages/core-fl/rollup.config.js
@@ -1,0 +1,37 @@
+// import typescript from '@rollup/plugin-typescript'
+import typescript from 'rollup-plugin-typescript2'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+import pkg from './package.json' assert { type: 'json' }
+
+export default {
+  input: 'src/index.ts',
+  plugins: [
+    nodeResolve({
+      extensions: ['.mjs', '.js', '.json', '.node']
+    }),
+    typescript()
+  ],
+  external: [
+    '@most/scheduler',
+    '@most/disposable',
+    '@most/prelude'
+  ],
+  output: [
+    {
+      file: pkg.main,
+      format: 'umd',
+      name: 'mostCoreFl',
+      sourcemap: true,
+      globals: {
+        '@most/scheduler': 'mostScheduler',
+        '@most/disposable': 'mostDisposable',
+        '@most/prelude': 'mostPrelude'
+      }
+    },
+    {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: true
+    }
+  ]
+}

--- a/packages/core-fl/src/FantasyLandStream.ts
+++ b/packages/core-fl/src/FantasyLandStream.ts
@@ -1,0 +1,58 @@
+import { Stream, Sink, Scheduler, Disposable } from '@most/types'
+import {
+  continueWith,
+  empty,
+  filter,
+  map,
+  ap,
+  now,
+  chain,
+  never
+} from '../../core'
+
+interface FunctorFantasyLand<A> {
+  ['fantasy-land/map']<B>(fn: (a: A) => B): FunctorFantasyLand<B>
+}
+
+export const fantasyLand = <A>(stream: Stream<A>): FantasyLandStream<A> =>
+  new FantasyLandStream(stream)
+
+export class FantasyLandStream<A> implements Stream<A>, FunctorFantasyLand<A> {
+  constructor(private readonly stream: Stream<A>) {}
+
+  run(sink: Sink<A>, scheduler: Scheduler): Disposable {
+    return this.stream.run(sink, scheduler)
+  }
+
+  ['fantasy-land/concat'](nextStream: Stream<A>): FantasyLandStream<A> {
+    return fantasyLand<A>(continueWith(() => nextStream, this.stream))
+  }
+
+  ['fantasy-land/empty']<B>() {
+    return fantasyLand<B>(empty())
+  }
+
+  ['fantasy-land/filter'](predicate: (value: A) => boolean) {
+    return fantasyLand<A>(filter(predicate, this.stream))
+  }
+
+  ['fantasy-land/map']<B>(fn: (value: A) => B): FantasyLandStream<B> {
+    return fantasyLand<B>(map(fn, this.stream))
+  }
+
+  ['fantasy-land/ap']<B>(mapper: Stream<(value: A) => B>) {
+    return fantasyLand<B>(ap(mapper, this.stream))
+  }
+
+  ['fantasy-land/of']<B>(value: B) {
+    return fantasyLand<B>(now(value))
+  }
+
+  ['fantasy-land/chain']<B>(fn: (value: A) => Stream<B>) {
+    return fantasyLand<B>(chain(fn, this.stream))
+  }
+
+  ['fantasy-land/zero']() {
+    return fantasyLand<A>(never())
+  }
+}

--- a/packages/core-fl/src/index.ts
+++ b/packages/core-fl/src/index.ts
@@ -1,0 +1,22 @@
+import { fantasyLand, FantasyLandStream } from './FantasyLandStream'
+import { compose, curry2 } from '@most/prelude'
+import { Stream } from '@most/types'
+
+import { periodic as _periodic, take as _take, tap as _tap } from '../../core/src'
+
+export const periodic = compose(fantasyLand, _periodic)
+
+interface Take {
+  <A>(n: number, s: Stream<A>): FantasyLandStream<A>
+  <A>(n: number): (s: Stream<A>) => FantasyLandStream<A>
+}
+export const take: Take = curry2((x, y) => fantasyLand(_take(x, y)))
+
+interface Tap {
+  <A>(f: (a: A) => any, s: Stream<A>): FantasyLandStream<A>
+  <A>(f: (a: A) => any): (s: Stream<A>) => FantasyLandStream<A>
+}
+export const tap: Tap = curry2((x, y) => fantasyLand(_tap(x, y)))
+
+export { fantasyLand, FantasyLandStream }
+export { runEffects } from '../../core'

--- a/packages/core-fl/test/fantasy-land-test.ts
+++ b/packages/core-fl/test/fantasy-land-test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'mocha'
+import { assert } from '@briancavalier/assert'
+import { newDefaultScheduler } from '@most/scheduler'
+import { Stream } from '@most/types'
+
+import { periodic, runEffects, take, tap, FantasyLandStream } from '../src/index'
+import { pipe } from 'fp-ts/function'
+import { map as mapR } from 'ramda'
+
+const map = mapR as unknown as <A, B>(fn: (x: A) => B) => (functor: FantasyLandStream<A>) => FantasyLandStream<B>
+
+const defaultScheduler = newDefaultScheduler()
+const runEff = <A>(s: Stream<A>): Promise<void> => runEffects(s, defaultScheduler)
+
+describe('fantasy-land', function () {
+  // const x = [0, 1, 2, 3]
+  // const sampleError = new Error('sample error')
+
+  it('the types should line up', function () {
+    return runEff(take(2, periodic(10)))
+      .then(res => {
+        assert(typeof res === 'undefined')
+      })
+  })
+
+  it('map', () => pipe(
+    periodic(10),
+    take(2),
+    map(() => 'foo'),
+    tap(x => {
+      assert(x === 'foo')
+    }),
+    runEff
+  ))
+})

--- a/packages/core-fl/tsconfig.json
+++ b/packages/core-fl/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist",
+    "target": "ES2020"
+  },
+  "extends": "../../tsconfig",
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/packages/core/src/combinator/continueWith.ts
+++ b/packages/core/src/combinator/continueWith.ts
@@ -60,7 +60,7 @@ class ContinueWithSink<A, B> extends Pipe<A, A | B> implements Sink<A>, Disposab
     try {
       this.disposable = this.continue(this.f, t, sink)
     } catch (e) {
-      sink.error(t, e)
+      sink.error(t, e as Error)
     }
   }
 

--- a/packages/core/src/combinator/errors.ts
+++ b/packages/core/src/combinator/errors.ts
@@ -90,7 +90,7 @@ class RecoverWithSink<A, E extends Error, B> implements Sink<A>, Disposable {
     try {
       this.disposable = this._continue(this.f, t, x, sink)
     } catch (e) {
-      sink.error(t, e)
+      sink.error(t, e as Error)
     }
   }
 

--- a/packages/core/src/combinator/mergeConcurrently.ts
+++ b/packages/core/src/combinator/mergeConcurrently.ts
@@ -72,7 +72,7 @@ class Outer<A, B> implements Sink<A>, Disposable {
     try {
       this.initInner(t, x)
     } catch (e) {
-      this.error(t, e)
+      this.error(t, e as Error)
     }
   }
 

--- a/packages/core/src/runEffects.ts
+++ b/packages/core/src/runEffects.ts
@@ -56,7 +56,7 @@ function tryDispose <X>(error: (e: Error) => void, end: (x: X) => void, x: X, di
   try {
     disposable.dispose()
   } catch (e) {
-    error(e)
+    error(e as Error)
     return
   }
 

--- a/packages/core/src/source/tryEvent.ts
+++ b/packages/core/src/source/tryEvent.ts
@@ -8,7 +8,7 @@ export function tryEvent <A>(t: Time, x: A, sink: Sink<A>): void {
   try {
     sink.event(t, x)
   } catch (e) {
-    sink.error(t, e)
+    sink.error(t, e as Error)
   }
 }
 
@@ -16,6 +16,6 @@ export function tryEnd(t: Time, sink: Sink<unknown>): void {
   try {
     sink.end(t)
   } catch (e) {
-    sink.error(t, e)
+    sink.error(t, e as Error)
   }
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -15,6 +15,6 @@ export function runTask <E, A>(task: DeferrableTask<E, A>): E | A {
   try {
     return task.run()
   } catch (e) {
-    return task.error(e)
+    return task.error(e as Error)
   }
 }


### PR DESCRIPTION
This is a proposal how one can provide @most/core-fl by rebuilding @most/core and wrapping the Stream type with a FantasylandStream type.

- no `import @most/core`, so everything remains in TypeScript,
- @most/core-fl is 100% backwards compatible to @most/core

The implementation is simple, however the typings get quite laborious

See [Fantasyland support issue](https://github.com/mostjs/core/issues/239)