### PR TITLE
Fix: Sphinx Theme CSS file missing on doc pages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,10 @@ build:
   tools:
     python: "3.12"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.todo', 'sphinx_rtd_theme']
+extensions = ['sphinx.ext.todo']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.todo']
+extensions = ['sphinx.ext.todo', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -82,7 +82,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1


### PR DESCRIPTION
Without knowing how to use Read the Docs I applied *some* instructions from here
https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html

Still [missing](https://readthedocs.org/projects/mostcore/builds/23694212/) is `pip install sphinx_rtd_theme`. I don't know where to add that 🤷

I noticed `theme.css` is no longer used for https://mostcore.readthedocs.io/en/latest/api.html

On [waybackmachine](https://web.archive.org/web/20200531094124/https://mostcore.readthedocs.io/en/latest/index.html) `theme.css` (`/* sphinx_rtd_theme version 0.4.3 | MIT license */
/* Built 20190212 16:02 */`) is used.

w/o the theme imo the docs look quite ugly now:
![Screenshot 2024-03-12 at 18 39 07](https://github.com/mostjs/core/assets/296476/c7bc9443-992f-427b-b3af-9a2e1ee5dfca)
